### PR TITLE
CI: Use Cache@2 task in place of Lighthouse

### DIFF
--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -30,12 +30,26 @@ jobs:
       - script: npm install --global npm@6.12.1
         displayName: Update npm
 
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-        displayName: Restore node_modules cache
+      - task: Cache@2
+        displayName: Cache node_modules
         inputs:
-          keyfile: 'package.json, script/vsts/platforms/linux.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+          key: 'npm | "$(Agent.OS)" | package.json, package-lock.json, script/vsts/platforms/linux.yml'
+          path: 'node_modules'
+          cacheHitVar: MainNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache script/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | script/package.json, script/package-lock.json, script/vsts/platforms/linux.yml'
+          path: 'script/node_modules'
+          cacheHitVar: ScriptNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache apm/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/linux.yml'
+          path: 'apm/node_modules'
+          cacheHitVar: ApmNodeModulesRestored
 
       - script: script/bootstrap
         displayName: Bootstrap build environment
@@ -45,14 +59,7 @@ jobs:
           CC: clang-5.0
           CXX: clang++-5.0
           npm_config_clang: 1
-        condition: ne(variables['CacheRestored'], 'true')
-
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-        displayName: Save node_modules cache
-        inputs:
-          keyfile: 'package.json, script/vsts/platforms/linux.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+        condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))
 
       - script: script/lint
         displayName: Run linter

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -20,12 +20,26 @@ jobs:
       - script: npm install --global npm@6.12.1
         displayName: Update npm
 
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-        displayName: Restore node_modules cache
+      - task: Cache@2
+        displayName: Cache node_modules
         inputs:
-          keyfile: 'package.json, script/vsts/platforms/macos.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+          key: 'npm | "$(Agent.OS)" | package.json, package-lock.json, script/vsts/platforms/macos.yml'
+          path: 'node_modules'
+          cacheHitVar: MainNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache script/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | script/package.json, script/package-lock.json, script/vsts/platforms/macos.yml'
+          path: 'script/node_modules'
+          cacheHitVar: ScriptNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache apm/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/macos.yml'
+          path: 'apm/node_modules'
+          cacheHitVar: ApmNodeModulesRestored
 
       - script: script/bootstrap
         displayName: Bootstrap build environment
@@ -34,14 +48,7 @@ jobs:
           CI_PROVIDER: VSTS
           NPM_BIN_PATH: /usr/local/bin/npm
           npm_config_build_from_source: true
-        condition: ne(variables['CacheRestored'], 'true')
-
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-        displayName: Save node_modules cache
-        inputs:
-          keyfile: 'package.json, script/vsts/platforms/macos.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+        condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))
 
       - script: script/lint
         displayName: Run linter
@@ -121,12 +128,26 @@ jobs:
       - script: npm install --global npm@6.12.1
         displayName: Update npm
 
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-        displayName: Restore node_modules cache
+      - task: Cache@2
+        displayName: Cache node_modules
         inputs:
-          keyfile: 'package.json, script/vsts/platforms/macos.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+          key: 'npm | "$(Agent.OS)" | package.json, package-lock.json, script/vsts/platforms/macos.yml'
+          path: 'node_modules'
+          cacheHitVar: MainNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache script/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | script/package.json, script/package-lock.json, script/vsts/platforms/macos.yml'
+          path: 'script/node_modules'
+          cacheHitVar: ScriptNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache apm/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/macos.yml'
+          path: 'apm/node_modules'
+          cacheHitVar: ApmNodeModulesRestored
 
       # The artifact caching task does not work on forks, so we need to
       # bootstrap again for pull requests coming from forked repositories.
@@ -137,8 +158,7 @@ jobs:
           CI_PROVIDER: VSTS
           NPM_BIN_PATH: /usr/local/bin/npm
           npm_config_build_from_source: true
-
-        condition: ne(variables['CacheRestored'], 'true')
+        condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))
 
       - task: DownloadBuildArtifacts@0
         displayName: Download atom-mac.zip

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -48,21 +48,26 @@ jobs:
           npm install
         displayName: Install Windows build dependencies
 
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-        displayName: Restore node_modules cache (x64)
+      - task: Cache@2
+        displayName: Cache node_modules
         inputs:
-          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-        condition: eq(variables['buildArch'], 'x64')
+          key: 'npm | "$(Agent.OS)" | "$(buildArch)" | package.json, package-lock.json, script/vsts/platforms/windows.yml'
+          path: 'node_modules'
+          cacheHitVar: MainNodeModulesRestored
 
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-        displayName: Restore node_modules cache (x86)
+      - task: Cache@2
+        displayName: Cache script/node_modules
         inputs:
-          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-        condition: eq(variables['buildArch'], 'x86')
+          key: 'npm | "$(Agent.OS)" | "$(buildArch)" | script/package.json, script/package-lock.json, script/vsts/platforms/windows.yml'
+          path: 'script/node_modules'
+          cacheHitVar: ScriptNodeModulesRestored
+
+      - task: Cache@2
+        displayName: Cache apm/node_modules
+        inputs:
+          key: 'npm | "$(Agent.OS)" | "$(buildArch)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/windows.yml'
+          path: 'apm/node_modules'
+          cacheHitVar: ApmNodeModulesRestored
 
       - script: |
           node script\vsts\windows-run.js script\bootstrap.cmd
@@ -73,23 +78,7 @@ jobs:
           NPM_BIN_PATH: "C:\\hostedtoolcache\\windows\\node\\12.13.1\\x64\\npm.cmd"
           npm_config_build_from_source: true
         displayName: Bootstrap build environment
-        condition: ne(variables['CacheRestored'], 'true')
-
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-        displayName: Save node_modules cache (x64)
-        inputs:
-          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-        condition: eq(variables['buildArch'], 'x64')
-
-      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-        displayName: Save node_modules cache (x86)
-        inputs:
-          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
-          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-        condition: eq(variables['buildArch'], 'x86')
+        condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))
 
       - script: node script\vsts\windows-run.js script\lint.cmd
         env:


### PR DESCRIPTION
<details><summary>Requirements for Adding, Changing, or Removing a Feature (from template)</summary>

### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Issue or RFC Endorsed by Atom's Maintainers

As discussed here: https://github.com/atom-ide-community/atom/pull/10#issuecomment-653980620

Alternative implementation of: https://github.com/atom-ide-community/atom/pull/11

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

Cache the `[repo_root]/node_modules`, `script/node_modules` and `apm/node_modules` folders with the official [`Cache@v2`](https://docs.microsoft.com/azure/devops/pipelines/release/caching?view=azure-devops) task, rather than the Microsoft DevLabs [Lighthouse-branded caching task](https://marketplace.visualstudio.com/items?itemName=1ESLighthouseEng.PipelineArtifactCaching).


This has several benefits: First, it's a newer, official project with a [dedicated and active support team behind it](https://github.com/microsoft/azure-pipelines-artifact-caching-tasks/issues/40#issuecomment-619713944). (the Lighthouse caching task is a DevLabs project, and is ["not officially supported"](https://github.com/microsoft/azure-pipelines-artifact-caching-tasks/issues/33#issuecomment-580041758).) The Lighthouse caching task must be installed from the marketplace, `Cache@v2` "just works", no install needed. The Lighthouse caching task needs a `vstsFeed` (Universal Artifact Feed) ID, which means manual reconfiguration for every fork. The new `Cache@v2` task doesn't ask for a feed ID, so it can work across any and all forks of Atom, no re-configuration needed!

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Alternative implementation of: #11

Alternate solution versus [#13 --> #27]

### Possible Drawbacks

The `Cache@v2` task only saves its cache if the entire job (bootstrap, build, test) completes.

There is no explicit "save" action we can do like there was in the Lighthouse caching task. `Cache@v2` only implicitly saves cache after the "job" completes. (We could split bootstrapping out into a separate job, but that's more refactoring than I want to do in one PR).

If there are issues with building a given branch, or the branch doesn't pass tests (including for cases of flaky tests), bootstrap cache won't be saved from that run.

That said, this effect is mitigated by the fact that caches from recent runs of `master` branch can be used. Furthermore, previous runs of the same branch can be used. For pull requests, previous runs of the target branch (to be merged into) can also be used. [Docs for opportunistic cache hits across different branches/refs](https://docs.microsoft.com/azure/devops/pipelines/release/caching?view=azure-devops#cache-isolation-and-security).

Once this PR has been around merged into the repository (especially `master`) for a bit, the chance of cache misses should go down a fair amount, so we should see less bootstrapping.

Some cache misses will still occur if we/upstream modify one or more of the `script/vsts/platforms/[linux.yml, macos.yml, windows.yml]` files, or any of the `[[repo_root], script/, apm/][package.json, package-lock.json]` files. But this is necessary, because in those cases it is fairly likely we do need to bootstrap again.

Not a regression in this PR, but a chance to maybe do better which I didn't try yet: (Perhaps the `script/vsts/platforms/*.yml` files can be taken out of the cache identifier. I think this might just have been a crude way of splitting out the caches by OS, and I copied it in case there was some other reason I'm unaware of. But bootstrapping "in the real world" (outside of CI) doesn't need these `vsts` files, so maybe we should drop them from the cache identifier for fewer cache misses. Hopefully we/upstream don't modify the `vsts` files too much, and it would be moot? Worth thinking about, though. The question is: Do changes to the `script/vsts/platforms/*.yml` files really indicate a need to do a fresh bootstrap? If yes, keep them in the cache identifier. If no, remove them. I suspect the answer is "no", and we can remove them.)

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Ran CI with these changes.

As expected: If the build/testing succeeds, cache saving also succeeds. Then on any subsequent run with a similar enough state of the repository (`package[-lock].json` files and `script/vsts/platforms*.yml files` are the same) the cache is restored and bootstrapping is skipped.

I anticipate fewer cache misses for a given platform after this hits `master` and there is at least one successful CI run on `master` for that platform.

Also, I read [the docs](https://docs.microsoft.com/azure/devops/pipelines/release/caching?view=azure-devops) fairly closely.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A