### PR TITLE
CI: Cache/restore the npm network/package cache

### DIFF
--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -28,4 +28,5 @@ steps:
       GITHUB_TOKEN: $(GITHUB_TOKEN)
       CI: true
       CI_PROVIDER: VSTS
+      npm_config_cache: $(Agent.BuildDirectory)/npm_package_cache_dir
     condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -12,6 +12,9 @@ steps:
     displayName: Cache node_modules
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
@@ -19,6 +22,9 @@ steps:
     displayName: Cache script/node_modules
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
@@ -26,5 +32,8 @@ steps:
     displayName: Cache apm/node_modules
     inputs:
       key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json
+         npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -37,3 +37,13 @@ steps:
          npm | "$(Agent.OS)" | "$(BUILD_ARCH)"
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored
+
+  - task: Cache@2
+    displayName: Cache npm package cache
+    inputs:
+      key: 'npm_package_cache | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package-lock.json, apm/package-lock.json, package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      restoreKeys: |
+         npm_package_cache | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package-lock.json, apm/package-lock.json, package-lock.json
+         npm_package_cache | "$(Agent.OS)" | "$(BUILD_ARCH)"
+         npm_package_cache
+      path: $(Agent.BuildDirectory)/npm_package_cache_dir

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -47,3 +47,5 @@ steps:
          npm_package_cache | "$(Agent.OS)" | "$(BUILD_ARCH)"
          npm_package_cache
       path: $(Agent.BuildDirectory)/npm_package_cache_dir
+    condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))
+    # No need to restore network/package cache if bootstrapping will be skipped!


### PR DESCRIPTION
This saves/restores the caches of just the packages.
(Not the installed and/or compiled versions, which are in node_modules;
We have already been caching those for some time now.)

<details><summary>Requirements for Adding, Changing, or Removing a Feature</summary>

### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Issue or RFC Endorsed by Atom's Maintainers

Discussed here: https://github.com/atom-ide-community/atom/pull/33#issuecomment-656477312

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

Cache not only the post-install `node_modules` folder, which we have been caching for some time now, but also the pre-install package/network cache that `npm` stores the packages from the registry in. This cache is there so you don't have to wait for your network connection to the registry, but can pull previously fetched packages straight from the hard disk.

In this case, caching it moves the network hit to "somewhere else in the Azure DevOps servers", which should hopefully be faster than hitting the npm registry.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Don't do this, and keep doing what we've been doing.

I'm trying this because I want to see if it is, in fact, faster. It's an experiment.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Could be slower than just hitting the npm package registry.

Or this could somehow be unreliable or add undesirable complexity. However, the `Cache@2` task is very well-behaved, being more likely to gracefully step out of the way and not do anything if it can't fully restore a cache. And npm fairly heavily validates everything that goes into/come out of the cache. So hopefully there's no issue with keeping the network/package cache around for multiple runs.

### Verification Process

Watch CI and see what happens.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A