### PR TITLE
Build Windows with MSVC 2019

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     dependsOn:
       - GetReleaseVersion
-      - Windows_RendererTests
+      - Windows_Tests
       - Linux
       - macOS_tests
 

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -56,7 +56,7 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      npm install --global --production windows-build-tools@4.0
+      npm install --global --production windows-build-tools@5.2.2
     displayName: Install windows build tools
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -56,11 +56,6 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      npm install --global --production windows-build-tools@5.2.2
-    displayName: Install windows build tools
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: |
       cd script\vsts
       npm install
     displayName: Install Windows build dependencies

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -14,7 +14,7 @@ jobs:
           RunCoreMainTests: true
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]
@@ -88,7 +88,7 @@ jobs:
           buildArch: x64
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -71,7 +71,7 @@ jobs:
               dir: $(Build.SourcesDirectory)/out
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
 
-  - job: Windows_RendererTests
+  - job: Windows_Tests
     displayName: Windows
     dependsOn: Windows_build
     timeoutInMinutes: 180
@@ -82,13 +82,20 @@ jobs:
           RunCoreMainTests: false
           RunCoreRendererTests: 1
           buildArch: x64
+          os: windows-2019
         x64_Renderer_Test2:
           RunCoreMainTests: false
           RunCoreRendererTests: 2
           buildArch: x64
+          os: windows-2019
+        2016_Main_Test:
+          RunCoreMainTests: true
+          RunCoreRendererTests: false
+          buildArch: x64
+          os: vs2017-win2016
 
     pool:
-      vmImage: windows-2019
+      vmImage: $(os)
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]
@@ -120,5 +127,5 @@ jobs:
           artifacts:
             -  atom$(FileID)-windows.zip
 
-      #  Core renderer tests
+      #  tests
       - template: templates/test.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     dependsOn:
       - GetReleaseVersion
-      - Windows_RendererTests
+      - Windows_Tests
       - Linux
       - macOS_tests
 


### PR DESCRIPTION
### Description of the change

This uses MSVC 2019 to build Atom on Windows. It does this on the windows-2019 image in Azure. To test the backward compatibility, the built Atom is tested on windows-2016.

### Verification
The tests pass. Extra tests are added to test the backward compatibility on older Windows.

### Drawbacks
none

### Release notes
- build Atom with MSVC 2019 on Windows. 
- use windows-2019 in the CI