### PR TITLE
CI: Skip uploading artifacts and crash reports to paid services if API key/secret env vars aren't set

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -47,9 +47,9 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
+          ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
+          ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
           PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
         displayName: Create Nightly Release
   - job: bump_dependencies

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,3 +1,9 @@
+variables:
+  ATOM_RELEASES_S3_KEY:  $[ variables['ATOM_RELEASES_S3_KEY'] ]
+  ATOM_RELEASES_S3_SECRET:  $[ variables['ATOM_RELEASES_S3_SECRET'] ]
+  ATOM_RELEASES_S3_BUCKET: $[ variables['ATOM_RELEASES_S3_BUCKET'] ]
+  PACKAGE_CLOUD_API_KEY: $[ variables['PACKAGE_CLOUD_API_KEY'] ]
+
 jobs:
   - job: GetReleaseVersion
     pool:

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -47,9 +47,9 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
-          ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
-          ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
           PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
         displayName: Create Nightly Release
   - job: bump_dependencies

--- a/script/vsts/platforms/templates/test.yml
+++ b/script/vsts/platforms/templates/test.yml
@@ -76,9 +76,9 @@ steps:
   - script: >
       node $(Build.SourcesDirectory)\script\vsts\upload-crash-reports.js --crash-report-path "%ARTIFACT_STAGING_DIR%\crash-reports" --s3-path "vsts-artifacts/%BUILD_ID%/"
     env:
-      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+      ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
+      ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
+      ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
       BUILD_ID: $(Build.BuildId)
     displayName: Upload crash reports to S3 on release branch

--- a/script/vsts/platforms/templates/test.yml
+++ b/script/vsts/platforms/templates/test.yml
@@ -76,9 +76,9 @@ steps:
   - script: >
       node $(Build.SourcesDirectory)\script\vsts\upload-crash-reports.js --crash-report-path "%ARTIFACT_STAGING_DIR%\crash-reports" --s3-path "vsts-artifacts/%BUILD_ID%/"
     env:
-      ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
-      ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
-      ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
+      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
       BUILD_ID: $(Build.BuildId)
     displayName: Upload crash reports to S3 on release branch

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -54,9 +54,9 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
+          ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
+          ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
           PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
         displayName: Create Draft Release
         condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
@@ -65,8 +65,8 @@ jobs:
           node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
         env:
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
+          ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
+          ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
         displayName: Upload CI Artifacts to S3
         condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -4,6 +4,12 @@ trigger:
   - electron-*
 pr: none # no PR triggers
 
+variables:
+  ATOM_RELEASES_S3_KEY:  $[ variables['ATOM_RELEASES_S3_KEY'] ]
+  ATOM_RELEASES_S3_SECRET:  $[ variables['ATOM_RELEASES_S3_SECRET'] ]
+  ATOM_RELEASES_S3_BUCKET: $[ variables['ATOM_RELEASES_S3_BUCKET'] ]
+  PACKAGE_CLOUD_API_KEY: $[ variables['PACKAGE_CLOUD_API_KEY'] ]
+
 jobs:
   - job: GetReleaseVersion
     pool:

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -54,9 +54,9 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
-          ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
-          ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
           PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
         displayName: Create Draft Release
         condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
@@ -65,8 +65,8 @@ jobs:
           node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
         env:
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: ${{ variables.ATOM_RELEASES_S3_KEY }}
-          ATOM_RELEASES_S3_SECRET: ${{ variables.ATOM_RELEASES_S3_SECRET }}
-          ATOM_RELEASES_S3_BUCKET: ${{ variables.ATOM_RELEASES_S3_BUCKET }}
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
         displayName: Upload CI Artifacts to S3
         condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -91,12 +91,21 @@ async function uploadArtifacts() {
   }
 
   if (argv.linuxRepoName) {
-    await uploadLinuxPackages(
-      argv.linuxRepoName,
-      process.env.PACKAGE_CLOUD_API_KEY,
-      releaseVersion,
-      assets
-    );
+    if (
+      process.env.PACKAGE_CLOUD_API_KEY &&
+      process.env.PACKAGE_CLOUD_API_KEY !== '$(PACKAGE_CLOUD_API_KEY)'
+    ) {
+      await uploadLinuxPackages(
+        argv.linuxRepoName,
+        process.env.PACKAGE_CLOUD_API_KEY,
+        releaseVersion,
+        assets
+      );
+    } else {
+      console.log(
+        '\nEnvironment variable "PACKAGE_CLOUD_API_KEY" is not set, skipping PackageCloud upload.'
+      );
+    }
   } else {
     console.log(
       '\nNo Linux package repo name specified, skipping Linux package upload.'

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -90,9 +90,7 @@ async function uploadArtifacts() {
   }
 
   if (argv.linuxRepoName) {
-    if (
-      process.env.PACKAGE_CLOUD_API_KEY
-    ) {
+    if (process.env.PACKAGE_CLOUD_API_KEY) {
       await uploadLinuxPackages(
         argv.linuxRepoName,
         process.env.PACKAGE_CLOUD_API_KEY,

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -65,19 +65,30 @@ async function uploadArtifacts() {
     return;
   }
 
-  console.log(
-    `Uploading ${
-      assets.length
-    } release assets for ${releaseVersion} to S3 under '${bucketPath}'`
-  );
+  if (
+    process.env.ATOM_RELEASES_S3_KEY &&
+    process.env.ATOM_RELEASES_S3_KEY !== '$(ATOM_RELEASES_S3_KEY)' &&
+    process.env.ATOM_RELEASES_S3_SECRET &&
+    process.env.ATOM_RELEASES_S3_SECRET !== '$(ATOM_RELEASES_S3_SECRET)'
+  ) {
+    console.log(
+      `Uploading ${
+        assets.length
+      } release assets for ${releaseVersion} to S3 under '${bucketPath}'`
+    );
 
-  await uploadToS3(
-    process.env.ATOM_RELEASES_S3_KEY,
-    process.env.ATOM_RELEASES_S3_SECRET,
-    process.env.ATOM_RELEASES_S3_BUCKET,
-    bucketPath,
-    assets
-  );
+    await uploadToS3(
+      process.env.ATOM_RELEASES_S3_KEY,
+      process.env.ATOM_RELEASES_S3_SECRET,
+      process.env.ATOM_RELEASES_S3_BUCKET,
+      bucketPath,
+      assets
+    );
+  } else {
+    console.log(
+      '\nEnvironment variables "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+    );
+  }
 
   if (argv.linuxRepoName) {
     await uploadLinuxPackages(

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -85,7 +85,7 @@ async function uploadArtifacts() {
     );
   } else {
     console.log(
-      '\nEnvironment variables "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+      '\nEnvironment variables "ATOM_RELEASES_S3_BUCKET", "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
     );
   }
 

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -67,9 +67,7 @@ async function uploadArtifacts() {
 
   if (
     process.env.ATOM_RELEASES_S3_KEY &&
-    process.env.ATOM_RELEASES_S3_KEY !== '$(ATOM_RELEASES_S3_KEY)' &&
-    process.env.ATOM_RELEASES_S3_SECRET &&
-    process.env.ATOM_RELEASES_S3_SECRET !== '$(ATOM_RELEASES_S3_SECRET)'
+    process.env.ATOM_RELEASES_S3_SECRET
   ) {
     console.log(
       `Uploading ${
@@ -92,8 +90,7 @@ async function uploadArtifacts() {
 
   if (argv.linuxRepoName) {
     if (
-      process.env.PACKAGE_CLOUD_API_KEY &&
-      process.env.PACKAGE_CLOUD_API_KEY !== '$(PACKAGE_CLOUD_API_KEY)'
+      process.env.PACKAGE_CLOUD_API_KEY
     ) {
       await uploadLinuxPackages(
         argv.linuxRepoName,

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -67,7 +67,8 @@ async function uploadArtifacts() {
 
   if (
     process.env.ATOM_RELEASES_S3_KEY &&
-    process.env.ATOM_RELEASES_S3_SECRET
+    process.env.ATOM_RELEASES_S3_SECRET &&
+    process.env.ATOM_RELEASES_S3_BUCKET
   ) {
     console.log(
       `Uploading ${

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -40,7 +40,7 @@ async function uploadCrashReports() {
   }
 }
 
-if (process.env.ATOM_RELEASES_S3_KEY && process.env.ATOM_RELEASES_S3_SECRET) {
+if (process.env.ATOM_RELEASES_S3_KEY && process.env.ATOM_RELEASES_S3_SECRET && process.env.ATOM_RELEASES_S3_BUCKET) {
   // Wrap the call the async function and catch errors from its promise because
   // Node.js doesn't yet allow use of await at the script scope
   uploadCrashReports().catch(err => {
@@ -49,6 +49,6 @@ if (process.env.ATOM_RELEASES_S3_KEY && process.env.ATOM_RELEASES_S3_SECRET) {
   });
 } else {
   console.log(
-    '\n\nEnvironment variables "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+    '\n\nEnvironment variables "ATOM_RELEASES_S3_BUCKET", "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
   );
 }

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -42,9 +42,7 @@ async function uploadCrashReports() {
 
 if (
   process.env.ATOM_RELEASES_S3_KEY &&
-  process.env.ATOM_RELEASES_S3_KEY !== '$(ATOM_RELEASES_S3_KEY)' &&
-  process.env.ATOM_RELEASES_S3_SECRET &&
-  process.env.ATOM_RELEASES_S3_SECRET !== '$(ATOM_RELEASES_S3_SECRET)'
+  process.env.ATOM_RELEASES_S3_SECRET
 ) {
   // Wrap the call the async function and catch errors from its promise because
   // Node.js doesn't yet allow use of await at the script scope

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -40,7 +40,11 @@ async function uploadCrashReports() {
   }
 }
 
-if (process.env.ATOM_RELEASES_S3_KEY && process.env.ATOM_RELEASES_S3_SECRET && process.env.ATOM_RELEASES_S3_BUCKET) {
+if (
+  process.env.ATOM_RELEASES_S3_KEY &&
+  process.env.ATOM_RELEASES_S3_SECRET &&
+  process.env.ATOM_RELEASES_S3_BUCKET
+) {
   // Wrap the call the async function and catch errors from its promise because
   // Node.js doesn't yet allow use of await at the script scope
   uploadCrashReports().catch(err => {

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -40,9 +40,20 @@ async function uploadCrashReports() {
   }
 }
 
-// Wrap the call the async function and catch errors from its promise because
-// Node.js doesn't yet allow use of await at the script scope
-uploadCrashReports().catch(err => {
-  console.error('An error occurred while uploading crash reports:\n\n', err);
-  process.exit(1);
-});
+if (
+  process.env.ATOM_RELEASES_S3_KEY &&
+  process.env.ATOM_RELEASES_S3_KEY !== '$(ATOM_RELEASES_S3_KEY)' &&
+  process.env.ATOM_RELEASES_S3_SECRET &&
+  process.env.ATOM_RELEASES_S3_SECRET !== '$(ATOM_RELEASES_S3_SECRET)'
+) {
+  // Wrap the call the async function and catch errors from its promise because
+  // Node.js doesn't yet allow use of await at the script scope
+  uploadCrashReports().catch(err => {
+    console.error('An error occurred while uploading crash reports:\n\n', err);
+    process.exit(1);
+  });
+} else {
+  console.log(
+    '\n\nEnvironment variables "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+  );
+}

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -40,10 +40,7 @@ async function uploadCrashReports() {
   }
 }
 
-if (
-  process.env.ATOM_RELEASES_S3_KEY &&
-  process.env.ATOM_RELEASES_S3_SECRET
-) {
+if (process.env.ATOM_RELEASES_S3_KEY && process.env.ATOM_RELEASES_S3_SECRET) {
   // Wrap the call the async function and catch errors from its promise because
   // Node.js doesn't yet allow use of await at the script scope
   uploadCrashReports().catch(err => {


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

https://github.com/atom-ide-community/atom/issues/1#issuecomment-663877340

### Description of the Change

- Skip uploading build artifacts to Amazon S3 if no credentials are set, in `script/vsts/upload-artifacts.js`
  - Similarly, skip uploading crash reports to Amazon S3 if credentials aren't set, in `script/vsts/upload-crash-reports.js`
- Skip uploading Linux packages (`.deb`, `.rpm`) to PackageCloud.io if API key isn't set, in `script/vsts/upload-artifacts.js`

This is to stop these uploads from being attempted with misconfigured/blank credentials or upload destinations. Such misconfigured uploads error out and cause our CI to fail at the last step, after all tests have passed.

### Alternate Designs

None.

### Possible Drawbacks

None

### Verification Process

CI is showing that these changes are working. See this comment for details: https://github.com/atom-ide-community/atom/pull/66#issuecomment-673524996


### Release Notes
N/A