### PR TITLE
CI: Faster GetReleaseVersion and Release/Upload Artifacts jobs

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -4,11 +4,11 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
+      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
-          npm install
-        displayName: npm install
+          npm ci
+        displayName: npm ci
       - script: node script/vsts/get-release-version.js --nightly
         name: Version
         env:
@@ -38,11 +38,11 @@ jobs:
       - template: platforms/templates/preparation.yml
 
        #This has to be done separately because VSTS inexplicably
-       #exits the script block after `npm install` completes.
+       #exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
-          npm install
-        displayName: npm install
+          npm ci
+        displayName: npm ci
 
       - task: DownloadBuildArtifacts@0
         inputs:
@@ -77,8 +77,8 @@ jobs:
 
       - script: |
           cd script/lib
-          npm install
-        displayName: npm install
+          npm ci
+        displayName: npm ci
       - script: |
           cd script/lib/update-dependency
           node index.js

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -23,7 +23,7 @@ jobs:
 
   - job: Release
     pool:
-      vmImage: vs2017-win2016
+      vmImage: 'ubuntu-latest'
 
     dependsOn:
       - GetReleaseVersion

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: GetReleaseVersion
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -6,10 +6,10 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
-      - script: node script\vsts\get-release-version.js --nightly
+      - script: node script/vsts/get-release-version.js --nightly
         name: Version
         env:
           REPO_OWNER: $(REPO_OWNER)
@@ -40,7 +40,7 @@ jobs:
        #This has to be done separately because VSTS inexplicably
        #exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
 
@@ -51,7 +51,7 @@ jobs:
         displayName: Download Release Artifacts
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom"
+          node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom"
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -6,11 +6,11 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
+      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
-          npm install
-        displayName: npm install
+          npm ci
+        displayName: npm ci
       - script: node script/vsts/get-release-version.js
         name: Version
         env:

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -8,10 +8,10 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
-      - script: node script\vsts\get-release-version.js
+      - script: node script/vsts/get-release-version.js
         name: Version
         env:
           REPO_OWNER: $(REPO_OWNER)

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -3,7 +3,7 @@ trigger: none # No CI builds, only PR builds
 jobs:
   - job: GetReleaseVersion
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -28,7 +28,7 @@ jobs:
 
   - job: UploadArtifacts
     pool:
-      vmImage: vs2017-win2016
+      vmImage: 'ubuntu-latest'
 
     dependsOn:
       - GetReleaseVersion

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -7,7 +7,7 @@ pr: none # no PR triggers
 jobs:
   - job: GetReleaseVersion
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
@@ -42,8 +42,6 @@ jobs:
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
     steps:
-      - template: platforms/templates/preparation.yml
-
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -12,10 +12,10 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         displayName: npm install
-      - script: node script\vsts\get-release-version.js
+      - script: node script/vsts/get-release-version.js
         name: Version
         env:
           REPO_OWNER: $(REPO_OWNER)
@@ -47,7 +47,7 @@ jobs:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.
       - script: |
-          cd script\vsts
+          cd script/vsts
           npm install
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
@@ -60,7 +60,7 @@ jobs:
         displayName: Download Release Artifacts
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
+          node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
@@ -75,7 +75,7 @@ jobs:
         condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
+          node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
         env:
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
           ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -10,11 +10,11 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
+      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
-          npm install
-        displayName: npm install
+          npm ci
+        displayName: npm ci
       - script: node script/vsts/get-release-version.js
         name: Version
         env:
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
+      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
-          npm install
+          npm ci
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
-        displayName: npm install
+        displayName: npm ci
 
       - task: DownloadBuildArtifacts@0
         inputs:


### PR DESCRIPTION
### Requirements for Contributing a Performance Improvement

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Description of the Change

Run GetReleaseVersion (the first step) and the "Release"/"Upload Artifacts" (the last step on the Nightly/Release Branch pipelines) on `ubuntu-latest`. This alone has the most profound performance impact.

> Doing `npm install` [and `git clone`] is slower on Windows, due to NTFS's poor performance writing lots of small files versus EXT4.
>
> Interesting discussion here: `https://github.com/rust-lang/rustup/issues/1540`

Beyond that, further tweak GetReleaseVersion to use [`npm ci`](https://docs.npmjs.com/cli/ci#description) rather than [`npm install`](https://docs.npmjs.com/cli/install). This saves up to about 25 to 40 seconds or so per run.

In order to run these jobs of CI on Ubuntu, backslashes `\` were converted to forward-slashes `/`. This has the side benefit that these jobs may now be run on any OS, should it be desirable to do so in the future.

<details><summary>Background on slashes ("\" and "/"):</summary>

The `cd` and `node` commands each perfectly understand forward-slashes `/` to be directory separators, if used in command-line arguments, regardless of OS (yes, even on Windows). There is no need to use Windows-only backslashes `\`, which are interpreted as escape characters on Unix-likes such as Ubuntu and macOS. As it turns out, we only ever use backslashes `\` in paths passed as command-line arguments to `cd` or `node`. So in all of our CI configs, it is never required that we use backslashes `\`, and we could replace all of them with forward-slashes `/` if we wanted to. I have left the conditional, Windows-only ones in for now, since they aren't hurting anything.)

</details>

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Quantitative Performance Benefits

About 30 seconds to 1 minute faster GetReleaseVersion (the very first stage of CI, which must finish for the rest of CI to happen).

Presumably similar impact to the final "make releases"/"upload artifacts" steps of CI.

Edit to add some informal "benchmarks" I ran for just the GetReleseVersion job:
https://dev.azure.com/DeeDeeG/b/_build/results?buildId=209&view=results

From fastest to slowest:
- Ubuntu Bionic (~22-25 seconds)
- macOS Catalina (~23-25 seconds)
- Ubuntu Xenial (~25-35 seconds)
- Ubuntu Focal (~30-37 seconds)
- Windows (either version) (~50 seconds to 1 minute 30 seconds)

I ran seven runs of this (again, informal benchmarks) and results were usually within those ranges, with some slower outliers.

Runs might be a bit faster on my personal fork with fetch-depth set to `7` for the implicit `git checkout` task. The `atomcommunity` Azure Pipelines project currently has it set to a more-conservative depth of `15`.

<!--

Describe the exact performance improvement observed (for example, reduced time to complete an operation, reduced memory use, etc.). Describe how you measured this change. Bonus points for including graphs that demonstrate the improvement or attached dumps from the built-in profiling tools.

-->

### Possible Drawbacks

None that I can think of. A pretty small and simple change for a minute or so of speedup.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Passed CI on my personal fork. Should pass CI here.

Compare runs before/after this PR to see that the typical GetReleaseVersion job is faster and takes a more consistent amount of time. With this PR, the GetReleaseVersion job lasts about 30 seconds or so every time. Before this PR, GetReleaseVersion lasted from about 1 minute to 1 minute 30 seconds.

I haven't compared the run time of the Release/Upload Artifacts jobs, because we have no passing runs of that. See the fix in #66 so we can start comparing run times for that. 

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

https://github.com/atom-ide-community/atom/issues/1#issuecomment-663889936
<!-- Enter any applicable Issues here -->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A