### PR TITLE
detect symbolic link packages

### DIFF
--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -419,15 +419,17 @@ module.exports = class PackageManager {
 
     for (const packageDirPath of this.packageDirPaths) {
       if (fs.isDirectorySync(packageDirPath)) {
-
         // checks for directories.
         // dirent is faster, but for checking symbolic link we need stat.
         const packageNames = fs
           .readdirSync(packageDirPath, { withFileTypes: true })
-          .filter(dirent => (
-            dirent.isDirectory() ||
-            (dirent.isSymbolicLink() && fs.isDirectorySync(path.join(packageDirPath, dirent.name))))
-          ).map(dirent => dirent.name);
+          .filter(
+            dirent =>
+              dirent.isDirectory() ||
+              (dirent.isSymbolicLink() &&
+                fs.isDirectorySync(path.join(packageDirPath, dirent.name)))
+          )
+          .map(dirent => dirent.name);
 
         for (const packageName of packageNames) {
           if (

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -419,10 +419,15 @@ module.exports = class PackageManager {
 
     for (const packageDirPath of this.packageDirPaths) {
       if (fs.isDirectorySync(packageDirPath)) {
+
+        // checks for directories.
+        // dirent is faster, but for checking symbolic link we need stat.
         const packageNames = fs
           .readdirSync(packageDirPath, { withFileTypes: true })
-          .filter(dirent => dirent.isDirectory())
-          .map(dirent => dirent.name);
+          .filter(dirent => (
+            dirent.isDirectory() ||
+            (dirent.isSymbolicLink() && fs.isDirectorySync(path.join(packageDirPath, dirent.name))))
+          ).map(dirent => dirent.name);
 
         for (const packageName of packageNames) {
           if (


### PR DESCRIPTION
### Description of the Change

This is a fix for https://github.com/atom/atom/pull/20899. It follows symbolic links and checks if they are a directory (`fs.isDirectorySync` does that internally). 

This only uses `fs.isDirectorySync` for symbolic links and still has higher performance compared to using this function for everything. `fs.dirent` is faster compared to `fs.stat`.

### Verification Process

- Make a symbolic link from a folder to `.atom/packages`
- This change now detects if that symbolic link is a directory. Previous pull request did not

### Applicable Issues

### Release Notes

- Fix the issue that symbolic links are not detected as packages in the previous nightly.


https://github.com/atom/atom/pull/21065