### PR TITLE
⬆️ electron@7.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "6.1.12",
+  "electronVersion": "7.3.2",
   "dependencies": {
     "@atom/nsfw": "1.0.26",
     "@atom/source-map-support": "^0.3.4",


### PR DESCRIPTION
This requires building all the native modules for Electron 7. 
- fuzzy-native
- nsfw

We should replace the old native modules like:
- @atom/nsfw with nfsw 2
- fuzzy-native with fuzzaldrin-plus-fast