### PR TITLE
Fix miscellaneous ci issues

### DIFF
--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -4,10 +4,8 @@ const request = require('request-promise-native');
 const repositoryRootPath = path.resolve(__dirname, '..', '..');
 const appMetadata = require(path.join(repositoryRootPath, 'package.json'));
 
-const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO
-  ? process.env.NIGHTLY_RELEASE_REPO
-  : 'atom-nightly-releases';
+const REPO_OWNER = process.env.REPO_OWNER || 'atom';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -4,8 +4,8 @@ const request = require('request-promise-native');
 const repositoryRootPath = path.resolve(__dirname, '..', '..');
 const appMetadata = require(path.join(repositoryRootPath, 'package.json'));
 
-const REPO_OWNER = process.env.REPO_OWNER;
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO;
+const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO ? process.env.NIGHTLY_RELEASE_REPO : 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -5,7 +5,9 @@ const repositoryRootPath = path.resolve(__dirname, '..', '..');
 const appMetadata = require(path.join(repositoryRootPath, 'package.json'));
 
 const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO ? process.env.NIGHTLY_RELEASE_REPO : 'atom-nightly-releases';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO
+  ? process.env.NIGHTLY_RELEASE_REPO
+  : 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -5,7 +5,8 @@ const repositoryRootPath = path.resolve(__dirname, '..', '..');
 const appMetadata = require(path.join(repositoryRootPath, 'package.json'));
 
 const REPO_OWNER = process.env.REPO_OWNER || 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
+const NIGHTLY_RELEASE_REPO =
+  process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/lib/release-notes.js
+++ b/script/vsts/lib/release-notes.js
@@ -3,9 +3,9 @@ const octokit = require('@octokit/rest')();
 const changelog = require('pr-changelog');
 const childProcess = require('child_process');
 
-const REPO_OWNER = process.env.REPO_OWNER;
-const MAIN_REPO = process.env.MAIN_REPO;
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO;
+const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
+const MAIN_REPO = process.env.MAIN_REPO ? process.env.MAIN_REPO : 'atom';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO ? process.env.NIGHTLY_RELEASE_REPO : 'atom-nightly-releases';
 
 module.exports.getRelease = async function(releaseVersion, githubToken) {
   if (githubToken) {

--- a/script/vsts/lib/release-notes.js
+++ b/script/vsts/lib/release-notes.js
@@ -5,7 +5,8 @@ const childProcess = require('child_process');
 
 const REPO_OWNER = process.env.REPO_OWNER || 'atom';
 const MAIN_REPO = process.env.MAIN_REPO || 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
+const NIGHTLY_RELEASE_REPO =
+  process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
 
 module.exports.getRelease = async function(releaseVersion, githubToken) {
   if (githubToken) {

--- a/script/vsts/lib/release-notes.js
+++ b/script/vsts/lib/release-notes.js
@@ -3,11 +3,9 @@ const octokit = require('@octokit/rest')();
 const changelog = require('pr-changelog');
 const childProcess = require('child_process');
 
-const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
-const MAIN_REPO = process.env.MAIN_REPO ? process.env.MAIN_REPO : 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO
-  ? process.env.NIGHTLY_RELEASE_REPO
-  : 'atom-nightly-releases';
+const REPO_OWNER = process.env.REPO_OWNER || 'atom';
+const MAIN_REPO = process.env.MAIN_REPO || 'atom';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
 
 module.exports.getRelease = async function(releaseVersion, githubToken) {
   if (githubToken) {

--- a/script/vsts/lib/release-notes.js
+++ b/script/vsts/lib/release-notes.js
@@ -5,7 +5,9 @@ const childProcess = require('child_process');
 
 const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
 const MAIN_REPO = process.env.MAIN_REPO ? process.env.MAIN_REPO : 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO ? process.env.NIGHTLY_RELEASE_REPO : 'atom-nightly-releases';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO
+  ? process.env.NIGHTLY_RELEASE_REPO
+  : 'atom-nightly-releases';
 
 module.exports.getRelease = async function(releaseVersion, githubToken) {
   if (githubToken) {

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     dependsOn:
       - GetReleaseVersion
-      - Windows
+      - Windows_RendererTests
       - Linux
       - macOS_tests
 

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -3,13 +3,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
           npm ci
-        displayName: npm ci
-      - script: node script/vsts/get-release-version.js --nightly
+          node get-release-version.js --nightly
         name: Version
 
   # Import OS-specific build definitions
@@ -34,8 +31,6 @@ jobs:
     steps:
       - template: platforms/templates/preparation.yml
 
-       #This has to be done separately because VSTS inexplicably
-       #exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
           npm ci

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -11,9 +11,6 @@ jobs:
         displayName: npm ci
       - script: node script/vsts/get-release-version.js --nightly
         name: Version
-        env:
-          REPO_OWNER: $(REPO_OWNER)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml
@@ -59,9 +56,6 @@ jobs:
           ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
           ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
           PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
-          REPO_OWNER: $(REPO_OWNER)
-          MAIN_REPO: $(MAIN_REPO)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
         displayName: Create Nightly Release
   - job: bump_dependencies
     displayName: Bump Dependencies

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -5,7 +5,6 @@ jobs:
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
     pool:
-      # This image is used to host the Docker container that runs the build
       vmImage: ubuntu-16.04
 
     steps:

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: Windows
+  - job: Windows_build
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
     strategy:
@@ -71,7 +71,7 @@ jobs:
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
 
   - job: Windows_RendererTests
-    dependsOn: Windows
+    dependsOn: Windows_build
     timeoutInMinutes: 180
     strategy:
       maxParallel: 2

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,5 +1,6 @@
 jobs:
   - job: Windows_build
+    displayName: Windows build
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
     strategy:
@@ -71,6 +72,7 @@ jobs:
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
 
   - job: Windows_RendererTests
+    displayName: Windows
     dependsOn: Windows_build
     timeoutInMinutes: 180
     strategy:

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -5,13 +5,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
           npm ci
-        displayName: npm ci
-      - script: node script/vsts/get-release-version.js
+          node get-release-version.js
         name: Version
 
   # Import OS-specific build definitions

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -13,9 +13,6 @@ jobs:
         displayName: npm ci
       - script: node script/vsts/get-release-version.js
         name: Version
-        env:
-          REPO_OWNER: $(REPO_OWNER)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -9,13 +9,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
           npm ci
-        displayName: npm ci
-      - script: node script/vsts/get-release-version.js
+          node get-release-version.js
         name: Version
 
   # Import OS-specific build definitions.
@@ -39,8 +36,6 @@ jobs:
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
     steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
       - script: |
           cd script/vsts
           npm ci

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -17,9 +17,6 @@ jobs:
         displayName: npm ci
       - script: node script/vsts/get-release-version.js
         name: Version
-        env:
-          REPO_OWNER: $(REPO_OWNER)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
 
   # Import OS-specific build definitions.
   - template: platforms/windows.yml
@@ -66,9 +63,6 @@ jobs:
           ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
           ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
           PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
-          REPO_OWNER: $(REPO_OWNER)
-          MAIN_REPO: $(MAIN_REPO)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
         displayName: Create Draft Release
         condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
 
@@ -79,8 +73,5 @@ jobs:
           ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
           ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
           ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-          REPO_OWNER: $(REPO_OWNER)
-          MAIN_REPO: $(MAIN_REPO)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
         displayName: Upload CI Artifacts to S3
         condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -32,7 +32,7 @@ jobs:
 
     dependsOn:
       - GetReleaseVersion
-      - Windows
+      - Windows_RendererTests
       - Linux
       - macOS_tests
 

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -14,7 +14,9 @@ const CONFIG = require('../config');
 
 const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
 const MAIN_REPO = process.env.MAIN_REPO ? process.env.MAIN_REPO : 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO ? process.env.NIGHTLY_RELEASE_REPO : 'atom-nightly-releases';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO
+  ? process.env.NIGHTLY_RELEASE_REPO
+  : 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -12,9 +12,9 @@ const uploadLinuxPackages = require('./lib/upload-linux-packages');
 
 const CONFIG = require('../config');
 
-const REPO_OWNER = process.env.REPO_OWNER;
-const MAIN_REPO = process.env.MAIN_REPO;
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO;
+const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
+const MAIN_REPO = process.env.MAIN_REPO ? process.env.MAIN_REPO : 'atom';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO ? process.env.NIGHTLY_RELEASE_REPO : 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -14,7 +14,8 @@ const CONFIG = require('../config');
 
 const REPO_OWNER = process.env.REPO_OWNER || 'atom';
 const MAIN_REPO = process.env.MAIN_REPO || 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
+const NIGHTLY_RELEASE_REPO =
+  process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -12,11 +12,9 @@ const uploadLinuxPackages = require('./lib/upload-linux-packages');
 
 const CONFIG = require('../config');
 
-const REPO_OWNER = process.env.REPO_OWNER ? process.env.REPO_OWNER : 'atom';
-const MAIN_REPO = process.env.MAIN_REPO ? process.env.MAIN_REPO : 'atom';
-const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO
-  ? process.env.NIGHTLY_RELEASE_REPO
-  : 'atom-nightly-releases';
+const REPO_OWNER = process.env.REPO_OWNER || 'atom';
+const MAIN_REPO = process.env.MAIN_REPO || 'atom';
+const NIGHTLY_RELEASE_REPO = process.env.NIGHTLY_RELEASE_REPO || 'atom-nightly-releases';
 
 const yargs = require('yargs');
 const argv = yargs


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

Fixes most of https://github.com/atom-ide-community/atom/issues/70

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

Update Windows job names.

- `Windows` --> `Windows_build` makes it more obvious this job simply builds Windows, nothing more.
  - `Windows_RendererTests` now depend on `Windows_build`, not `Windows`.
  - `Release` now depends on `Windows_RendererTests`, not `Windows`.

Delete a comment about containers in Linux preparation
- We don't run the Linux build in an Ubuntu 14.04 "Trusty Tahr" Docker container anymore like upstream does. We run directly in a virtualized Ubuntu 16.04 "Xenial Xerus" image for now.

Set fallback/default values for the `REPO` metadata variables: `REPO_OWNER` --> `'atom'`; `MAIN_REPO` --> `'atom'`; `NIGHTLY_RELEASE_REPO` --> `'atom-nightly-releases'`
  - We can override these to match our own repos.

Delete an old workaround that's no longer applicable, with `npm install` in a scrfipt block, immefiately followed by another script block
  - This no longer "inexplicably exits after `npm install`", so just combine the two adjacent script blocks.
  - Delete the comment explaining the workaround, since it's no longer true, AND because this PR drops the workaround altogether.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Not fix these (admittedly minor) issues?

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

None that I know of. Watch to make sure that deleting `cd script/vsts && npm install` on Windows doesn't somehow cause problems.

Watch to make sure I didn't typo the job names under Windows.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

CI should pass. Reviewing the diff should confirm there are no typos in the PR.

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A