### PR TITLE
CI: Move GetReleaseVersion to its own template

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,6 +1,8 @@
 jobs:
-  # Import "GetReleaseVersion" job definition
+  # Import "GetReleaseVersion" job definition, with the "NightlyFlag" parameter set
   - template: platforms/templates/get-release-version.yml
+    parameters:
+      NightlyFlag: --nightly
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,5 +1,5 @@
 jobs:
-  # Import "GetReleaseVersion" job definition, with the "NightlyFlag" parameter set
+  # GetReleaseVersion for nightly release
   - template: platforms/templates/get-release-version.yml
     parameters:
       NightlyFlag: --nightly

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,19 +1,6 @@
 jobs:
-  - job: GetReleaseVersion
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
-      - script: |
-          cd script/vsts
-          npm ci
-        displayName: npm ci
-      - script: node script/vsts/get-release-version.js --nightly
-        name: Version
-        env:
-          REPO_OWNER: $(REPO_OWNER)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
+  # Import "GetReleaseVersion" job definition
+  - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -1,0 +1,17 @@
+jobs:
+
+- job: GetReleaseVersion
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    # This has to be done separately because VSTS inexplicably
+    # exits the script block after `npm ci` completes.
+    - script: |
+        cd script/vsts
+        npm ci
+      displayName: npm ci
+    - script: node script/vsts/get-release-version.js
+      name: Version
+      env:
+        REPO_OWNER: $(REPO_OWNER)
+        NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -1,3 +1,11 @@
+parameters:
+  - name: NightlyFlag
+    type: string
+    values:
+      - ' '
+      - --nightly
+    default: ' '
+
 jobs:
 
 - job: GetReleaseVersion
@@ -10,7 +18,7 @@ jobs:
         cd script/vsts
         npm ci
       displayName: npm ci
-    - script: node script/vsts/get-release-version.js
+    - script: node script/vsts/get-release-version.js ${{ parameters.NightlyFlag }}
       name: Version
       env:
         REPO_OWNER: $(REPO_OWNER)

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,7 +1,7 @@
 trigger: none # No CI builds, only PR builds
 
 jobs:
-  # Import "GetReleaseVersion" job definition
+  # GetReleaseVersion
   - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,21 +1,8 @@
 trigger: none # No CI builds, only PR builds
 
 jobs:
-  - job: GetReleaseVersion
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
-      - script: |
-          cd script/vsts
-          npm ci
-        displayName: npm ci
-      - script: node script/vsts/get-release-version.js
-        name: Version
-        env:
-          REPO_OWNER: $(REPO_OWNER)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
+  # Import "GetReleaseVersion" job definition
+  - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -5,7 +5,7 @@ trigger:
 pr: none # no PR triggers
 
 jobs:
-  # Import "GetReleaseVersion" job definition
+  # GetReleaseVersion
   - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions.

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -5,21 +5,8 @@ trigger:
 pr: none # no PR triggers
 
 jobs:
-  - job: GetReleaseVersion
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
-      - script: |
-          cd script/vsts
-          npm ci
-        displayName: npm ci
-      - script: node script/vsts/get-release-version.js
-        name: Version
-        env:
-          REPO_OWNER: $(REPO_OWNER)
-          NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)
+  # Import "GetReleaseVersion" job definition
+  - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions.
   - template: platforms/windows.yml


### PR DESCRIPTION
<details><summary>Requirements for Adding, Changing, or Removing a Feature (from template)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Issue or RFC Endorsed by Atom's Maintainers

https://github.com/atom-ide-community/atom/issues/69

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

Move the `GetReleaseVersion` job of CI into its own template.

This job had been written out verbatim (no differences) in the three main pipepline config files (`script/vsts` ... `pull-request.yml`, `release-branch-build.yml`, and `nightly-release.yml`). Instead, we can have the code only in one place, for [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)ness reasons.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

This is a just a small improvement. Alternative would be... don't merge this and just do what we've been doing before. i.e. the same code written out verbatim in three separate `.yml` config files.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

None expected.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

CI runs, including the `GetReleaseVersion` job. I tested this on the Pull Requests and Release Branch Build pipelines so far. We don't tend to run the Nightly Release pipeline much at this time, but I can do a quick run of that as well.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A

or

- Move the GetReleaseVersion job to a template in CI