### PR TITLE
Switch apm to @atom-ide-community/atom-package-manager

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "npm:@atom-ide-community/atom-package-manager@2.5.0-atomic.1.1",
-      "resolved": "https://registry.npmjs.org/@atom-ide-community/atom-package-manager/-/atom-package-manager-2.5.0-atomic.1.1.tgz",
-      "integrity": "sha512-9E2N/KM3Ro73JD+YBBfm2xLy6BK5L7oMGN1AOC7ssslYr0Pj7QsgNlAyVNXM0gx45/LhVZwPTEFBXY+CQHyZrg==",
+      "version": "npm:@atom-ide-community/atom-package-manager@2.5.0-atomic.2.1",
+      "resolved": "https://registry.npmjs.org/@atom-ide-community/atom-package-manager/-/atom-package-manager-2.5.0-atomic.2.1.tgz",
+      "integrity": "sha512-Lw9aDrxfTSKaHlhQzIW4Xg0yn7KhFl2Cm7xuO3E9Qh72w1oZSdc40kaeY7KvTHV6P6/aQ9iz3mtdKdv31WXb4g==",
       "requires": {
         "@atom/plist": "0.4.4",
         "asar-require": "0.3.0",

--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.5.0.tgz",
-      "integrity": "sha512-bCD2GAfKZDiTmVQOn63yVonUsouesyyn//5H4Y9BEcBKRSD3JmUxyYF2ivner1TQg9HGuHG86z2gr7BkFg+9Mg==",
+      "version": "npm:@atom-ide-community/atom-package-manager@2.5.0-atomic.1.1",
+      "resolved": "https://registry.npmjs.org/@atom-ide-community/atom-package-manager/-/atom-package-manager-2.5.0-atomic.1.1.tgz",
+      "integrity": "sha512-9E2N/KM3Ro73JD+YBBfm2xLy6BK5L7oMGN1AOC7ssslYr0Pj7QsgNlAyVNXM0gx45/LhVZwPTEFBXY+CQHyZrg==",
       "requires": {
         "@atom/plist": "0.4.4",
         "asar-require": "0.3.0",
@@ -16,7 +16,7 @@
         "fs-plus": "2.x",
         "git-utils": "^5.6.2",
         "hosted-git-info": "^2.1.4",
-        "keytar": "^4.0",
+        "keytar": "^4.13.0",
         "mv": "2.0.0",
         "ncp": "~0.5.1",
         "npm": "^6.14.4",
@@ -50,9 +50,9 @@
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -165,9 +165,9 @@
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+          "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
         },
         "balanced-match": {
           "version": "1.0.0",
@@ -582,9 +582,9 @@
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -775,11 +775,11 @@
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
         },
@@ -1033,9 +1033,9 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-abi": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
-          "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
+          "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
           "requires": {
             "semver": "^5.4.1"
           }
@@ -1054,9 +1054,9 @@
           }
         },
         "npm": {
-          "version": "6.14.5",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.5.tgz",
-          "integrity": "sha512-CDwa3FJd0XJpKDbWCST484H+mCNjF26dPrU+xnREW+upR0UODjMEfXPl3bxWuAwZIX6c2ASg1plLO7jP8ehWeA==",
+          "version": "6.14.7",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
+          "integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
           "requires": {
             "JSONStream": "^1.3.5",
             "abbrev": "~1.1.1",
@@ -1064,7 +1064,7 @@
             "ansistyles": "~0.1.3",
             "aproba": "^2.0.0",
             "archy": "~1.0.0",
-            "bin-links": "^1.1.7",
+            "bin-links": "^1.1.8",
             "bluebird": "^3.5.5",
             "byte-size": "^5.0.1",
             "cacache": "^12.0.3",
@@ -1085,7 +1085,7 @@
             "find-npm-prefix": "^1.0.2",
             "fs-vacuum": "~1.2.10",
             "fs-write-stream-atomic": "~1.0.10",
-            "gentle-fs": "^2.3.0",
+            "gentle-fs": "^2.3.1",
             "glob": "^7.1.6",
             "graceful-fs": "^4.2.4",
             "has-unicode": "~2.0.1",
@@ -1100,14 +1100,14 @@
             "is-cidr": "^3.0.0",
             "json-parse-better-errors": "^1.0.2",
             "lazy-property": "~1.0.0",
-            "libcipm": "^4.0.7",
+            "libcipm": "^4.0.8",
             "libnpm": "^3.0.1",
             "libnpmaccess": "^3.0.2",
             "libnpmhook": "^5.0.3",
             "libnpmorg": "^1.0.1",
             "libnpmsearch": "^2.0.2",
             "libnpmteam": "^1.0.2",
-            "libnpx": "^10.2.2",
+            "libnpx": "^10.2.4",
             "lock-verify": "^2.1.0",
             "lockfile": "^1.0.4",
             "lodash._baseindexof": "*",
@@ -1129,15 +1129,15 @@
             "node-gyp": "^5.1.0",
             "nopt": "^4.0.3",
             "normalize-package-data": "^2.5.0",
-            "npm-audit-report": "^1.3.2",
+            "npm-audit-report": "^1.3.3",
             "npm-cache-filename": "~1.0.2",
             "npm-install-checks": "^3.0.2",
-            "npm-lifecycle": "^3.1.4",
+            "npm-lifecycle": "^3.1.5",
             "npm-package-arg": "^6.1.1",
             "npm-packlist": "^1.4.8",
             "npm-pick-manifest": "^3.0.2",
             "npm-profile": "^4.0.4",
-            "npm-registry-fetch": "^4.0.4",
+            "npm-registry-fetch": "^4.0.5",
             "npm-user-validate": "~1.0.0",
             "npmlog": "~4.1.2",
             "once": "~1.4.0",
@@ -1323,7 +1323,7 @@
               }
             },
             "bin-links": {
-              "version": "1.1.7",
+              "version": "1.1.8",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.3",
@@ -1458,23 +1458,36 @@
               }
             },
             "cliui": {
-              "version": "4.1.0",
+              "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
               },
               "dependencies": {
                 "ansi-regex": {
-                  "version": "3.0.0",
+                  "version": "4.1.0",
                   "bundled": true
                 },
-                "strip-ansi": {
-                  "version": "4.0.0",
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^3.0.0"
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
                   }
                 }
               }
@@ -1788,6 +1801,10 @@
               "version": "1.0.0",
               "bundled": true
             },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "bundled": true
+            },
             "encoding": {
               "version": "0.1.12",
               "bundled": true,
@@ -1894,13 +1911,6 @@
             "find-npm-prefix": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
             },
             "flush-write-stream": {
               "version": "1.0.3",
@@ -2079,7 +2089,7 @@
               "bundled": true
             },
             "gentle-fs": {
-              "version": "2.3.0",
+              "version": "2.3.1",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.2",
@@ -2106,7 +2116,7 @@
               }
             },
             "get-caller-file": {
-              "version": "1.0.3",
+              "version": "2.0.5",
               "bundled": true
             },
             "get-stream": {
@@ -2300,10 +2310,6 @@
                 "validate-npm-package-name": "^3.0.0"
               }
             },
-            "invert-kv": {
-              "version": "2.0.0",
-              "bundled": true
-            },
             "ip": {
               "version": "1.1.5",
               "bundled": true
@@ -2458,15 +2464,8 @@
               "version": "1.0.0",
               "bundled": true
             },
-            "lcid": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "^2.0.0"
-              }
-            },
             "libcipm": {
-              "version": "4.0.7",
+              "version": "4.0.8",
               "bundled": true,
               "requires": {
                 "bin-links": "^1.1.2",
@@ -2475,7 +2474,7 @@
                 "find-npm-prefix": "^1.0.2",
                 "graceful-fs": "^4.1.11",
                 "ini": "^1.3.5",
-                "lock-verify": "^2.0.2",
+                "lock-verify": "^2.1.0",
                 "mkdirp": "^0.5.1",
                 "npm-lifecycle": "^3.0.0",
                 "npm-logical-tree": "^1.2.1",
@@ -2621,7 +2620,7 @@
               }
             },
             "libnpx": {
-              "version": "10.2.2",
+              "version": "10.2.4",
               "bundled": true,
               "requires": {
                 "dotenv": "^5.0.1",
@@ -2631,15 +2630,7 @@
                 "update-notifier": "^2.3.0",
                 "which": "^1.3.0",
                 "y18n": "^4.0.0",
-                "yargs": "^11.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "yargs": "^14.2.3"
               }
             },
             "lock-verify": {
@@ -2751,31 +2742,9 @@
                 "ssri": "^6.0.0"
               }
             },
-            "map-age-cleaner": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "p-defer": "^1.0.0"
-              }
-            },
             "meant": {
               "version": "1.0.1",
               "bundled": true
-            },
-            "mem": {
-              "version": "4.3.0",
-              "bundled": true,
-              "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-              },
-              "dependencies": {
-                "mimic-fn": {
-                  "version": "2.1.0",
-                  "bundled": true
-                }
-              }
             },
             "mime-db": {
               "version": "1.35.0",
@@ -2867,10 +2836,6 @@
               "version": "0.0.7",
               "bundled": true
             },
-            "nice-try": {
-              "version": "1.0.5",
-              "bundled": true
-            },
             "node-fetch-npm": {
               "version": "2.0.2",
               "bundled": true,
@@ -2925,7 +2890,7 @@
               }
             },
             "npm-audit-report": {
-              "version": "1.3.2",
+              "version": "1.3.3",
               "bundled": true,
               "requires": {
                 "cli-table3": "^0.5.0",
@@ -2951,7 +2916,7 @@
               }
             },
             "npm-lifecycle": {
-              "version": "3.1.4",
+              "version": "3.1.5",
               "bundled": true,
               "requires": {
                 "byline": "^5.0.0",
@@ -3010,7 +2975,7 @@
               }
             },
             "npm-registry-fetch": {
-              "version": "4.0.4",
+              "version": "4.0.5",
               "bundled": true,
               "requires": {
                 "JSONStream": "^1.3.4",
@@ -3023,7 +2988,7 @@
               },
               "dependencies": {
                 "safe-buffer": {
-                  "version": "5.2.0",
+                  "version": "5.2.1",
                   "bundled": true
                 }
               }
@@ -3088,41 +3053,6 @@
               "version": "1.0.2",
               "bundled": true
             },
-            "os-locale": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-              },
-              "dependencies": {
-                "cross-spawn": {
-                  "version": "6.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "nice-try": "^1.0.4",
-                    "path-key": "^2.0.1",
-                    "semver": "^5.5.0",
-                    "shebang-command": "^1.2.0",
-                    "which": "^1.2.9"
-                  }
-                },
-                "execa": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "cross-spawn": "^6.0.0",
-                    "get-stream": "^4.0.0",
-                    "is-stream": "^1.1.0",
-                    "npm-run-path": "^2.0.0",
-                    "p-finally": "^1.0.0",
-                    "signal-exit": "^3.0.0",
-                    "strip-eof": "^1.0.0"
-                  }
-                }
-              }
-            },
             "os-tmpdir": {
               "version": "1.0.2",
               "bundled": true
@@ -3135,33 +3065,7 @@
                 "os-tmpdir": "^1.0.0"
               }
             },
-            "p-defer": {
-              "version": "1.0.0",
-              "bundled": true
-            },
             "p-finally": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "p-is-promise": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "p-limit": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "p-try": "^1.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
               "version": "1.0.0",
               "bundled": true
             },
@@ -3516,7 +3420,7 @@
               "bundled": true
             },
             "require-main-filename": {
-              "version": "1.0.1",
+              "version": "2.0.0",
               "bundled": true
             },
             "resolve-from": {
@@ -3686,7 +3590,7 @@
               }
             },
             "spdx-license-ids": {
-              "version": "3.0.3",
+              "version": "3.0.5",
               "bundled": true
             },
             "split-on-first": {
@@ -4079,20 +3983,36 @@
               }
             },
             "wrap-ansi": {
-              "version": "2.1.0",
+              "version": "5.1.0",
               "bundled": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
               },
               "dependencies": {
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
                 "string-width": {
-                  "version": "1.0.2",
+                  "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
                   }
                 }
               }
@@ -4127,34 +4047,93 @@
               "bundled": true
             },
             "yargs": {
-              "version": "11.1.1",
+              "version": "14.2.3",
               "bundled": true,
               "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.1.0",
+                "cliui": "^5.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
+                "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
+                "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "y18n": "^4.0.0",
+                "yargs-parser": "^15.0.1"
               },
               "dependencies": {
-                "y18n": {
-                  "version": "3.2.1",
+                "ansi-regex": {
+                  "version": "4.1.0",
                   "bundled": true
+                },
+                "find-up": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "^3.0.0"
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "locate-path": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-locate": "^3.0.0",
+                    "path-exists": "^3.0.0"
+                  }
+                },
+                "p-limit": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-try": "^2.0.0"
+                  }
+                },
+                "p-locate": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-limit": "^2.0.0"
+                  }
+                },
+                "p-try": {
+                  "version": "2.2.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
+                  }
                 }
               }
             },
             "yargs-parser": {
-              "version": "9.0.2",
+              "version": "15.0.1",
               "bundled": true,
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "5.3.1",
+                  "bundled": true
+                }
               }
             }
           }
@@ -4381,9 +4360,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4434,9 +4413,9 @@
           "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
         "simple-concat": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
         },
         "simple-get": {
           "version": "2.8.1",

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "2.5.0"
+    "atom-package-manager": "npm:@atom-ide-community/atom-package-manager@^2.5.0-atomic.1.1"
   }
 }

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "npm:@atom-ide-community/atom-package-manager@^2.5.0-atomic.1.1"
+    "atom-package-manager": "npm:@atom-ide-community/atom-package-manager@^2.5.0-atomic.2.1"
   }
 }


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

Helps with #44 

### Description of the Change

Use a fork of apm that's updated more frequently. By the same maintainers working on this fork of Atom. This fork is somewhat conservatively updated with needed fixes/dependency updates, and quality of life improvements.

Right now, the changes are limited to:
- Newer bundled Node (that exactly matches the version of Node that Electron 6 is based on, which we ship at this fork of Atom).
- Better support for Visual Studio 2017 and newer
- Normalized line endings (`CR/LF`) so that releases can be properly published from a Windows machine.

<details><summary>See the Changelogs:</summary>

- https://github.com/atom-ide-community/apm/releases/tag/2.5.0-atomic.2
  - No change line-endings fix: https://github.com/atom-ide-community/apm/releases/tag/2.5.0-atomic.2.1
- https://github.com/atom-ide-community/apm/releases/tag/2.5.0-atomic.1
  - No change line-endings fix: https://github.com/atom-ide-community/apm/releases/tag/2.5.0-atomic.1.1
- https://github.com/atom-ide-community/apm/releases/tag/2.5.0+0.1.0

</details>

### Alternate Designs
None

### Possible Drawbacks
None.

### Verification Process
CI should pass, manual testing shows that this works as a drop-in replacement with all the commands I've tried.

### Release Notes

Switch apm to `@atom-ide-community/atom-package-manager` (comes with bundled Node v12.4.0)