### PR TITLE
CI: option to skip upload

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,3 +1,9 @@
+variables:
+  ATOM_RELEASES_S3_KEY:  $[ variables['ATOM_RELEASES_S3_KEY'] ]
+  ATOM_RELEASES_S3_SECRET:  $[ variables['ATOM_RELEASES_S3_SECRET'] ]
+  ATOM_RELEASES_S3_BUCKET: $[ variables['ATOM_RELEASES_S3_BUCKET'] ]
+  PACKAGE_CLOUD_API_KEY: $[ variables['PACKAGE_CLOUD_API_KEY'] ]
+
 jobs:
   # GetReleaseVersion for nightly release
   - template: platforms/templates/get-release-version.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -4,6 +4,12 @@ trigger:
   - electron-*
 pr: none # no PR triggers
 
+variables:
+  ATOM_RELEASES_S3_KEY:  $[ variables['ATOM_RELEASES_S3_KEY'] ]
+  ATOM_RELEASES_S3_SECRET:  $[ variables['ATOM_RELEASES_S3_SECRET'] ]
+  ATOM_RELEASES_S3_BUCKET: $[ variables['ATOM_RELEASES_S3_BUCKET'] ]
+  PACKAGE_CLOUD_API_KEY: $[ variables['PACKAGE_CLOUD_API_KEY'] ]
+
 jobs:
   # GetReleaseVersion
   - template: platforms/templates/get-release-version.yml

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -65,27 +65,43 @@ async function uploadArtifacts() {
     return;
   }
 
-  console.log(
-    `Uploading ${
-      assets.length
-    } release assets for ${releaseVersion} to S3 under '${bucketPath}'`
-  );
+  if (
+    process.env.ATOM_RELEASES_S3_KEY &&
+    process.env.ATOM_RELEASES_S3_SECRET &&
+    process.env.ATOM_RELEASES_S3_BUCKET
+  ) {
+    console.log(
+      `Uploading ${
+        assets.length
+      } release assets for ${releaseVersion} to S3 under '${bucketPath}'`
+    );
 
-  await uploadToS3(
-    process.env.ATOM_RELEASES_S3_KEY,
-    process.env.ATOM_RELEASES_S3_SECRET,
-    process.env.ATOM_RELEASES_S3_BUCKET,
-    bucketPath,
-    assets
-  );
-
-  if (argv.linuxRepoName) {
-    await uploadLinuxPackages(
-      argv.linuxRepoName,
-      process.env.PACKAGE_CLOUD_API_KEY,
-      releaseVersion,
+    await uploadToS3(
+      process.env.ATOM_RELEASES_S3_KEY,
+      process.env.ATOM_RELEASES_S3_SECRET,
+      process.env.ATOM_RELEASES_S3_BUCKET,
+      bucketPath,
       assets
     );
+  } else {
+    console.log(
+      '\nEnvironment variables "ATOM_RELEASES_S3_BUCKET", "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+    );
+  }
+
+  if (argv.linuxRepoName) {
+    if (process.env.PACKAGE_CLOUD_API_KEY) {
+      await uploadLinuxPackages(
+        argv.linuxRepoName,
+        process.env.PACKAGE_CLOUD_API_KEY,
+        releaseVersion,
+        assets
+      );
+    } else {
+      console.log(
+        '\nEnvironment variable "PACKAGE_CLOUD_API_KEY" is not set, skipping PackageCloud upload.'
+      );
+    }
   } else {
     console.log(
       '\nNo Linux package repo name specified, skipping Linux package upload.'

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -40,9 +40,19 @@ async function uploadCrashReports() {
   }
 }
 
-// Wrap the call the async function and catch errors from its promise because
-// Node.js doesn't yet allow use of await at the script scope
-uploadCrashReports().catch(err => {
-  console.error('An error occurred while uploading crash reports:\n\n', err);
-  process.exit(1);
-});
+if (
+  process.env.ATOM_RELEASES_S3_KEY &&
+  process.env.ATOM_RELEASES_S3_SECRET &&
+  process.env.ATOM_RELEASES_S3_BUCKET
+) {
+  // Wrap the call the async function and catch errors from its promise because
+  // Node.js doesn't yet allow use of await at the script scope
+  uploadCrashReports().catch(err => {
+    console.error('An error occurred while uploading crash reports:\n\n', err);
+    process.exit(1);
+  });
+} else {
+  console.log(
+    '\n\nEnvironment variables "ATOM_RELEASES_S3_BUCKET", "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.'
+  );
+}


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

https://github.com/atom-ide-community/atom/issues/1#issuecomment-663877340

### Description of the Change

- Skip uploading build artifacts to Amazon S3 if no credentials are set, in `script/vsts/upload-artifacts.js`
  - Similarly, skip uploading crash reports to Amazon S3 if credentials aren't set, in `script/vsts/upload-crash-reports.js`
- Skip uploading Linux packages (`.deb`, `.rpm`) to PackageCloud.io if API key isn't set, in `script/vsts/upload-artifacts.js`

This is to stop these uploads from being attempted with misconfigured/blank credentials or upload destinations. Such misconfigured uploads error out and cause our CI to fail at the last step, after all tests have passed.

### Alternate Designs

None.

### Possible Drawbacks

None

### Verification Process

CI is showing that these changes are working. See this comment for details: https://github.com/atom-ide-community/atom/pull/66#issuecomment-673524996


### Release Notes
N/A