### PR TITLE
apm: Update apm/package-lock.json

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -565,9 +565,9 @@
           },
           "dependencies": {
             "type": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-              "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+              "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
             }
           }
         },
@@ -1033,9 +1033,9 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-abi": {
-          "version": "2.18.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
-          "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.0.tgz",
+          "integrity": "sha512-rpKqVe24p9GvMTgtqUXdLR1WQJBGVlkYPU10qHKv9/1i9V/k04MmFLVK2WcHBf1WKKY+ZsdvARPi8F4tfJ4opA==",
           "requires": {
             "semver": "^5.4.1"
           }
@@ -1054,9 +1054,9 @@
           }
         },
         "npm": {
-          "version": "6.14.7",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
-          "integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
+          "version": "6.14.8",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
+          "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
           "requires": {
             "JSONStream": "^1.3.5",
             "abbrev": "~1.1.1",
@@ -1122,7 +1122,7 @@
             "lodash.uniq": "~4.5.0",
             "lodash.without": "~4.4.0",
             "lru-cache": "^5.1.1",
-            "meant": "~1.0.1",
+            "meant": "^1.0.2",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.5",
             "move-concurrently": "^1.0.1",
@@ -1137,7 +1137,7 @@
             "npm-packlist": "^1.4.8",
             "npm-pick-manifest": "^3.0.2",
             "npm-profile": "^4.0.4",
-            "npm-registry-fetch": "^4.0.5",
+            "npm-registry-fetch": "^4.0.7",
             "npm-user-validate": "~1.0.0",
             "npmlog": "~4.1.2",
             "once": "~1.4.0",
@@ -1588,10 +1588,10 @@
               }
             },
             "configstore": {
-              "version": "3.1.2",
+              "version": "3.1.5",
               "bundled": true,
               "requires": {
-                "dot-prop": "^4.1.0",
+                "dot-prop": "^4.2.1",
                 "graceful-fs": "^4.1.2",
                 "make-dir": "^1.0.0",
                 "unique-string": "^1.0.0",
@@ -1742,7 +1742,7 @@
               }
             },
             "dot-prop": {
-              "version": "4.2.0",
+              "version": "4.2.1",
               "bundled": true,
               "requires": {
                 "is-obj": "^1.0.0"
@@ -2743,7 +2743,7 @@
               }
             },
             "meant": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "bundled": true
             },
             "mime-db": {
@@ -2763,6 +2763,10 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true
             },
             "minizlib": {
               "version": "1.3.3",
@@ -2975,7 +2979,7 @@
               }
             },
             "npm-registry-fetch": {
-              "version": "4.0.5",
+              "version": "4.0.7",
               "bundled": true,
               "requires": {
                 "JSONStream": "^1.3.4",
@@ -3300,12 +3304,6 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.5",
-                  "bundled": true
-                }
               }
             },
             "read": {


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

None.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Commit an updated `apm/package-lock.json`.

This has the following benefits:

- Makes `apm/package-lock.json` satisfy the requirements of `apm/package.json` fully again, meaning `npm` should be able to install the exact versions from `apm/package-lock.json`; We should get a deterministic set of dependencies for `apm` again.
- For CI: `apm/package-lock.json` no longer changes by the end of bootstrapping, so caches that get saved will match, and be restoreable.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

`script/bootstrap` now completes without causing `apm/package-lock.json` to change.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

 N/A