### PR TITLE
CI: Windows: Build with MSVC 2017 and test on 2019

### DIFF
--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -43,7 +43,7 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      npm install --global --production @aminya/windows-build-tools
+      npm install --global --production windows-build-tools@4
     displayName: Install windows build tools
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -43,6 +43,11 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
+      npm install --global --production @aminya/windows-build-tools
+    displayName: Install windows build tools
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+  - script: |
       ECHO Installing npm-windows-upgrade
       npm install --global --production npm-windows-upgrade
     displayName: Install npm-windows-upgrade

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -43,11 +43,6 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      npm install --global --production windows-build-tools@4
-    displayName: Install windows build tools
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: |
       ECHO Installing npm-windows-upgrade
       npm install --global --production npm-windows-upgrade
     displayName: Install npm-windows-upgrade

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -14,7 +14,7 @@ jobs:
           RunCoreMainTests: true
 
     pool:
-      vmImage: windows-2019
+      vmImage: vs2017-win2016
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]
@@ -88,11 +88,6 @@ jobs:
           RunCoreRendererTests: 2
           buildArch: x64
           os: windows-2019
-        2016_Main_Test:
-          RunCoreMainTests: true
-          RunCoreRendererTests: false
-          buildArch: x64
-          os: vs2017-win2016
 
     pool:
       vmImage: $(os)


### PR DESCRIPTION
### Description of the change

This uses MSVC 2017 to build Atom on Windows. Performs the test on Win 2019.

This is a patch for #44 

Closes https://github.com/atom-ide-community/atom/issues/117