### PR TITLE
Merge upstream master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 ### JavaScript Styleguide
 
-All JavaScript must adhere to [JavaScript Standard Style](https://standardjs.com/).
+All JavaScript code is linted with [Prettier](https://prettier.io/).
 
 * Prefer the object spread operator (`{...anotherObj}`) to `Object.assign()`
 * Inline `export`s with expressions whenever possible

--- a/packages/incompatible-packages/styles/incompatible-packages.less
+++ b/packages/incompatible-packages/styles/incompatible-packages.less
@@ -8,8 +8,8 @@
     padding: 15px;
     margin-bottom: 10px;
     border-radius: 6px;
-    border: 1px solid #d1d1d2;
-    background-color: #fafafa;
+    border: 1px solid @base-border-color;
+    background-color: lighten(@tool-panel-background-color, 8%);
     overflow: hidden;
 
     .badge {

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -35,8 +35,8 @@ jobs:
 
       - script: |
           cd script/vsts
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
 
       - task: DownloadBuildArtifacts@0
         inputs:
@@ -68,8 +68,8 @@ jobs:
 
       - script: |
           cd script/lib
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
       - script: |
           cd script/lib/update-dependency
           node index.js

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -6,7 +6,7 @@ steps:
         $env:npm_config_build_from_source=true
       }
       if ($env:AGENT_OS -eq "Darwin") {
-        $env:NPM_BIN_PATH="/Users/runner/hostedtoolcache/node/12.4.0/x64/bin/npm"
+        $env:NPM_BIN_PATH="/usr/local/bin/npm"
         $env:npm_config_build_from_source=true
       }
       if ($env:AGENT_OS -eq "Linux") {

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -11,20 +11,20 @@ steps:
   - task: Cache@2
     displayName: Cache node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm_main | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache apm/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(BUILD_ARCH)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm_apm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -27,14 +27,13 @@ steps:
 
   - script: npm install --global npm@6.14.8
     displayName: Update npm
-    condition: ne(variables['Agent.OS'], 'Darwin')
 
+  # Use Azure Syntax to set env variables for all shells and steps
   - pwsh: |
       if ($env:AGENT_OS -eq "Windows_NT") {
         $env:BUILD_ARCH=$env:buildArch
-        echo "##vso[task.setvariable variable=BUILD_ARCH]$env:BUILD_ARCH" # Azure syntax
+        echo "##vso[task.setvariable variable=BUILD_ARCH]$env:BUILD_ARCH"
       }
-      echo BUILD_ARCH: $env:BUILD_ARCH
     displayName: Setting globally used env variables
 
   # Windows Specific
@@ -58,5 +57,5 @@ steps:
   - script: |
       cd script\vsts
       npm install
-    displayName: Install Windows build dependencies
+    displayName: Install script/vsts dependencies on Windows
     condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -38,10 +38,10 @@ jobs:
     steps:
       - script: |
           cd script/vsts
-          npm ci
+          npm install
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
-        displayName: npm ci
+        displayName: npm install
 
       - task: DownloadBuildArtifacts@0
         inputs:

--- a/src/package.js
+++ b/src/package.js
@@ -77,9 +77,9 @@ module.exports = class Package {
   }
 
   measure(key, fn) {
-    const startTime = Date.now();
+    const startTime = window.performance.now();
     const value = fn();
-    this[key] = Date.now() - startTime;
+    this[key] = Math.round(window.performance.now() - startTime);
     return value;
   }
 


### PR DESCRIPTION
Just merging in a few changes from upstream.

We have gone back to `npm install` vs `npm ci` for installing `script/vsts/node_modules` dependencies. There are so few dependencies there that it only saved about 5 seconds or so to use `npm ci`, and that's on average. It varies a fair amount. I can live with this, I suppose.

I might still like to revert that change, but that would be in a follow-up commit or PR. Keeping the "merge from upstream" PR clean, faithful to what changed upstream.

There were a couple of improved comments in the templates. And on macOS the system `npm` path is used, rather than the `npm` shipped with Node. (Still gets updated to the pinned version we set it to, though? I'll take a close look and double-check once CI starts for this PR.) I went with this, because it's what upstream is doing. If we want to change that here, it's probably worth changing it at upstream as well, for consistency's sake.