### PR TITLE
Retry timed out steps automatically

### DIFF
--- a/script/test
+++ b/script/test
@@ -102,16 +102,15 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
 
 	// on close
   cp.on('close', exitCode => {
-    if (exitCode !== 0) {
-      console.log(`##[error] Tests for ${testName} failed.`.red)
-      console.log(stderrOutput)
-    }
-    if (finalize) { finalize() } 		// if finalizer provided
-    callback(null, {
-      exitCode,
-      step: testName,
-      testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
-    })
+   if (finalize) { finalize() } 		// if finalizer provided
+   callback(null, {
+     exitCode,
+     step: testName,
+     testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
+   })
+   if (exitCode !== 0) {
+     retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize)
+   }
   })
 
 }

--- a/script/test
+++ b/script/test
@@ -100,17 +100,18 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
     callback(error)
   })
 
-	// on close
+  // on close
   cp.on('close', exitCode => {
-   if (finalize) { finalize() } 		// if finalizer provided
-   if (exitCode !== 0) {
-     retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize)
-   }
-	 callback(null, {
-		 exitCode,
-		 step: testName,
-		 testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
-	 })
+    if (finalize) { finalize() } 		// if finalizer provided
+    if (exitCode !== 0) {
+      retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize)
+    } else {
+      callback(null, {
+        exitCode,
+        step: testName,
+        testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
+      })
+    }
   })
 
 }
@@ -131,6 +132,11 @@ function retryOrFailTest(stderrOutput, executablePath, testArguments, options, c
     // fail the test
     console.log(`##[error] Tests for ${testName} failed.`.red)
     console.log(stderrOutput)
+    callback(null, {
+      exitCode,
+      step: testName,
+      testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
+    })
   }
 }
 

--- a/script/test
+++ b/script/test
@@ -116,6 +116,24 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
 
 }
 
+const retryNumber = 1 // the number of times a tests repeats
+const retriedTests = new Map() // a cache of retried tests
+
+// Retries the tests if it is timed out for a number of times. Fails the rest of the tests or those that are tried enough times.
+function retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize) {
+  const testKey = createTestKey(executablePath, testArguments, testName)
+  if (isTimedOut(stderrOutput) && shouldTryAgain(testKey)) {
+    // retry the timed out test
+    let triedNumber = retriedTests.get(testKey) || 0
+    retriedTests.set(testKey, triedNumber + 1)
+    console.warn(`\n##[warning] Retrying the timed out step: ${testName} \n`)
+    spawnTest(executablePath, testArguments, options, callback, testName, finalize)
+  } else {
+    // fail the test
+    console.log(`##[error] Tests for ${testName} failed.`.red)
+    console.log(stderrOutput)
+  }
+}
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
   const testArguments = [

--- a/script/test
+++ b/script/test
@@ -148,6 +148,17 @@ function isTimedOut(stderrOutput) {
     return false
   }
 }
+
+// check if a tests should be tried again
+function shouldTryAgain(testKey) {
+  if (retriedTests.has(testKey)) {
+    return (retriedTests.get(testKey) < retryNumber)
+  } else {
+    return true
+  }
+}
+
+
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
   const testArguments = [

--- a/script/test
+++ b/script/test
@@ -139,6 +139,15 @@ function retryOrFailTest(stderrOutput, executablePath, testArguments, options, c
 function createTestKey(executablePath, testArguments, testName) {
   return `${executablePath} ${testArguments.join(' ')} ${testName}`
 }
+
+// check if a test is timed out
+function isTimedOut(stderrOutput) {
+  if (stderrOutput) {
+    return ( stderrOutput.includes("timeout: timed out after") )
+  } else {
+    return false
+  }
+}
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
   const testArguments = [

--- a/script/test
+++ b/script/test
@@ -104,7 +104,7 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
   cp.on('close', exitCode => {
     if (finalize) { finalize() } 		// if finalizer provided
     if (exitCode !== 0) {
-      retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize)
+      retryOrFailTest(stderrOutput, exitCode, executablePath, testArguments, options, callback, testName, finalize)
     } else {
       callback(null, {
         exitCode,
@@ -120,7 +120,7 @@ const retryNumber = 1 // the number of times a tests repeats
 const retriedTests = new Map() // a cache of retried tests
 
 // Retries the tests if it is timed out for a number of times. Fails the rest of the tests or those that are tried enough times.
-function retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize) {
+function retryOrFailTest(stderrOutput, exitCode, executablePath, testArguments, options, callback, testName, finalize) {
   const testKey = createTestKey(executablePath, testArguments, testName)
   if (isTimedOut(stderrOutput) && shouldTryAgain(testKey)) {
     // retry the timed out test

--- a/script/test
+++ b/script/test
@@ -134,6 +134,11 @@ function retryOrFailTest(stderrOutput, executablePath, testArguments, options, c
     console.log(stderrOutput)
   }
 }
+
+// creates a key that is specific to a certain test
+function createTestKey(executablePath, testArguments, testName) {
+  return `${executablePath} ${testArguments.join(' ')} ${testName}`
+}
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
   const testArguments = [

--- a/script/test
+++ b/script/test
@@ -103,14 +103,14 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
 	// on close
   cp.on('close', exitCode => {
    if (finalize) { finalize() } 		// if finalizer provided
-   callback(null, {
-     exitCode,
-     step: testName,
-     testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
-   })
    if (exitCode !== 0) {
      retryOrFailTest(stderrOutput, executablePath, testArguments, options, callback, testName, finalize)
    }
+	 callback(null, {
+		 exitCode,
+		 step: testName,
+		 testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
+	 })
   })
 
 }

--- a/script/test
+++ b/script/test
@@ -116,7 +116,7 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
 
 }
 
-const retryNumber = 1 // the number of times a tests repeats
+const retryNumber = 4 // the number of times a tests repeats
 const retriedTests = new Map() // a cache of retried tests
 
 // Retries the tests if it is timed out for a number of times. Fails the rest of the tests or those that are tried enough times.

--- a/script/test
+++ b/script/test
@@ -305,7 +305,7 @@ async.series(testSuitesToRun, function (err, results) {
     const failedSteps = results.filter(({exitCode}) => exitCode !== 0)
 
     if (failedSteps.length > 0) {
-      console.warn("##[error] \n \n *** Reporting the errors that happened in all of the tests: *** \n \n")
+      console.warn("\n \n ##[error] *** Reporting the errors that happened in all of the tests: *** \n \n")
       for (const {step, testCommand} of failedSteps) {
         console.error(`##[error] The '${step}' test step finished with a non-zero exit code \n ${testCommand}`)
       }


### PR DESCRIPTION
### Description of the change

This automatically detects the timed out tests and reruns them. 

This is much faster than rerunning the tests manually in Azure. This is because the rerunning happens at a low JavaScript level compared to CI reruns that need to set up the whole environment and rerun all the tests just because one was timed out.

### Verification
The CI passes. The functions are commented with details.

### Release Notes
N/A