### PR TITLE
CI: Really skip uploading artifacts to S3

### DIFF
--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -65,8 +65,8 @@ jobs:
           node $(Build.SourcesDirectory)/script/vsts/upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
         env:
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          ATOM_RELEASES_S3_KEY: $(_ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(_ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(_ATOM_RELEASES_S3_BUCKET)
         displayName: Upload CI Artifacts to S3
         condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

https://github.com/atom-ide-community/atom/issues/1#issuecomment-663877340, follow-up to: https://github.com/atom-ide-community/atom/pull/66, which was re-worked and landed as https://github.com/atom-ide-community/atom/pull/99.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fix a spot where we missed using the re-mapped S3 and PackageCloud env vars.

(For the condition where `IsSignedZipBranch` is true, we were still using the un-re-mapped variables. That would cause them to always be set to not-very-useful `$(VAR_NAME_HERE)` values. That oversight defeated our skipping mechanism. This patch makes skipping uploads to S3 and PackageCloud work properly again.)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

See this passing CI run to confirm that it worked: https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=738&view=logs&j=fc7b8a14-4c68-54ee-1e90-04bf630ba360&t=9ad4a9bf-2116-54e4-db45-9da1e971fb4f

> Environment variables "ATOM_RELEASES_S3_BUCKET", "ATOM_RELEASES_S3_KEY" and/or "ATOM_RELEASES_S3_SECRET" are not set, skipping S3 upload.
>
> No Linux package repo name specified, skipping Linux package upload.
> Skipping GitHub release creation
>
> Finishing: Upload CI Artifacts to S3


### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A