### PR TITLE
CI: Simplify preparation on Windows, Use Python 3.8 on all OSes

### DIFF
--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -2,7 +2,7 @@ steps:
   - pwsh: |
       # OS specific env variables
       if ($env:AGENT_OS -eq "Windows_NT") {
-        $env:NPM_BIN_PATH="C:/hostedtoolcache/windows/node/12.4.0/x64/npm.cmd"
+        $env:NPM_BIN_PATH="C:/npm/prefix/npm.cmd"
         $env:npm_config_build_from_source=true
       }
       if ($env:AGENT_OS -eq "Darwin") {

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -28,12 +28,11 @@ steps:
   - script: npm install --global npm@6.14.8
     displayName: Update npm
 
-  # Windows Specific
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.8'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
+  # Windows Specific
   - script: |
       cd script\vsts
       npm install

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -35,18 +35,6 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      ECHO Installing npm-windows-upgrade
-      npm install --global --production npm-windows-upgrade
-    displayName: Install npm-windows-upgrade
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: |
-      ECHO Upgrading npm
-      npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.14.8
-    displayName: Install npm 6.14.8
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: |
       cd script\vsts
       npm install
     displayName: Install script/vsts dependencies on Windows


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Don't update npm twice. Once is enough.
  - Delete these redundant steps: `npm install -g npm-windows-upgrade` and `npm-windows-upgrade`.
  - Keep the `npm install -g npm` command.
    - The `npm install -g npm` command modifies the npm at `C:/npm/prefix/npm.cmd`. So we set the `NPM_BIN_PATH` environment variable to point to that path instead of `C:/hostedtoolcache/windows/node/[maj.min.patch]/x64/npm.cmd`, which is the install that `npm-windows-upgrade` modifies.
- Set the Python version in the "Common" (all OSes) section of preparation, rather than doing this only on Windows.

### Quantitative Performance Benefits

<!--

Describe the exact performance improvement observed (for example, reduced time to complete an operation, reduced memory use, etc.). Describe how you measured this change. Bonus points for including graphs that demonstrate the improvement or attached dumps from the built-in profiling tools.

-->

About 45 seconds is saved before bootstrapping/building on Windows, and another 45 seconds is saved in each Windows test job.

- Installing `npm-windows-upgrade` takes about 20 seconds
- Running `npm-windows-upgrade` takes about 24 or 25 seconds.

See the time taken for those steps in this CI run for an example: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=625&view=logs&j=2985f0af-e798-5fdc-91b8-be9f0a3685c5&t=33143b02-a236-56d5-9221-c8b903d3c111

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

CI Passes. For example: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=624&view=results

Windows correctly uses npm 6.14.8 as we have configured it to. See: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=624&view=logs&j=2985f0af-e798-5fdc-91b8-be9f0a3685c5&t=9ceed7b2-fba1-5410-fd8f-91cfc59f4174 to confirm.

### Applicable Issues

<!-- Enter any applicable Issues here -->

Closes #51.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A