### PR TITLE
CI: Simplify redundant "buildArch" and "BUILD_ARCH" variables into one variable

### DIFF
--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -28,14 +28,6 @@ steps:
   - script: npm install --global npm@6.14.8
     displayName: Update npm
 
-  # Use Azure Syntax to set env variables for all shells and steps
-  - pwsh: |
-      if ($env:AGENT_OS -eq "Windows_NT") {
-        $env:BUILD_ARCH=$env:buildArch
-        echo "##vso[task.setvariable variable=BUILD_ARCH]$env:BUILD_ARCH"
-      }
-    displayName: Setting globally used env variables
-
   # Windows Specific
   - task: UsePythonVersion@0
     inputs:

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -7,10 +7,10 @@ jobs:
       maxParallel: 2
       matrix:
         x64:
-          buildArch: x64
+          BUILD_ARCH: x64
           RunCoreMainTests: true
         x86:
-          buildArch: x86
+          BUILD_ARCH: x86
           RunCoreMainTests: true
 
     pool:
@@ -32,8 +32,6 @@ jobs:
       - template: templates/bootstrap.yml
 
       - script: node script\vsts\windows-run.js script\lint.cmd
-        env:
-          BUILD_ARCH: $(buildArch)
         displayName: Run linter
 
       - template: templates/build.yml
@@ -47,8 +45,6 @@ jobs:
             $env:FileID=""
           }
           echo "##vso[task.setvariable variable=FileID]$env:FileID" # Azure syntax
-        env:
-          BUILD_ARCH: $(buildArch)
         displayName: Set FileID based on the arch
 
       - template: templates/publish.yml
@@ -81,12 +77,12 @@ jobs:
         x64_Renderer_Test1:
           RunCoreMainTests: false
           RunCoreRendererTests: 1
-          buildArch: x64
+          BUILD_ARCH: x64
           os: windows-2019
         x64_Renderer_Test2:
           RunCoreMainTests: false
           RunCoreRendererTests: 2
-          buildArch: x64
+          BUILD_ARCH: x64
           os: windows-2019
 
     pool:
@@ -113,8 +109,6 @@ jobs:
             $env:FileID="-x64"
             echo "##vso[task.setvariable variable=FileID]$env:FileID" # Azure syntax
           }
-        env:
-          BUILD_ARCH: $(buildArch)
         displayName: Set FileID based on the arch
 
       - template: templates/download-unzip.yml


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Use `BUILD_ARCH` everywhere. (Eliminate `buildArch`.)

I'm doing this rather than what we were doing before, which was setting `buildArch`, then setting `BUILD_ARCH` equal to `buildArch` and then using the value from `BUILD_ARCH`. This was unnecessarily complicated and 100% redundant.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

CI passes. Node 32-bit is still used on the Windows 32-bit jobs, Node 64-bit is still used for the Windows 64-bit jobs. (`buildArch` and `BUILD_ARCH` haven't ever been set on OSes other than Windows.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A