### PR TITLE
Update branch automatically using rebase bot

### DIFF
--- a/.github/rebase.yml
+++ b/.github/rebase.yml
@@ -1,0 +1,18 @@
+on:
+  issue_comment:
+    types: [created]
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && github.event.comment.author_association == 'OWNER' && contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of the change

This allows updating a branch automatically by commenting `/rebase` on a pull request. This is helpful to update the old branches especially for the branches created by the dependency updater bots.
