### PR TITLE
linux dpkg-deb: speed up build

### DIFF
--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -208,8 +208,13 @@ module.exports = function(packagedAppPath) {
     compressionLevel = 6;
     compressionType = 'xz';
   }
+  // use sudo if available to speed up build
+  let sudoCommand = 'fakeroot';
+  if (process.env.CI === true || (process.getuid && process.getuid() === 0)) {
+    sudoCommand = 'sudo';
+  }
   spawnSync(
-    'fakeroot',
+    sudoCommand,
     [
       'dpkg-deb',
       `-Z${compressionType}`,

--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -200,9 +200,27 @@ module.exports = function(packagedAppPath) {
   );
 
   console.log(`Generating .deb file from ${debianPackageDirPath}`);
-  spawnSync('fakeroot', ['dpkg-deb', '-b', debianPackageDirPath], {
-    stdio: 'inherit'
-  });
+
+  // don't compress by default to speed up build
+  let compressionLevel = 0;
+  let compressionType = 'none';
+  if (process.env.IS_RELEASE_BRANCH || process.env.IS_SIGNED_ZIP_BRANCH) {
+    compressionLevel = 6;
+    compressionType = 'xz';
+  }
+  spawnSync(
+    'fakeroot',
+    [
+      'dpkg-deb',
+      `-Z${compressionType}`,
+      `-z${compressionLevel}`,
+      '-b',
+      debianPackageDirPath
+    ],
+    {
+      stdio: 'inherit'
+    }
+  );
 
   console.log(
     `Copying generated package into "${outputDebianPackageFilePath}"`

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -4,7 +4,7 @@ steps:
   - script: |
       sudo apt-get update
       sudo apt-get install -y wget software-properties-common
-      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2 libicu-dev
+      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2 libicu-dev dpkg
       # clang 9 is included in the image
       sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10
       sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10


### PR DESCRIPTION
### Description of the change

This PR speeds up the build process of dpkg-deb on the Linux machines (by about 3 min):
- It uses `sudo` when available instead of `fakeroot`
- It does not compress the artifacts internally unless we are on a release/nightly branch. 


### Verification

Before changes (16 min and 38 seconds): https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=878&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=cccdf131-0893-5d7b-ccea-9ccfc8953f95

After changes(13min and 18seconds): https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=879&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=cccdf131-0893-5d7b-ccea-9ccfc8953f95


### Release Notes
- Faster builds by dpkg-deb on Linux