### PR TITLE
exclude test folders from the packaged app

### DIFF
--- a/script/lib/include-path-in-packaged-app.js
+++ b/script/lib/include-path-in-packaged-app.js
@@ -81,6 +81,14 @@ const EXCLUDE_REGEXPS_SOURCES = [
     escapeRegExp(path.sep) +
     '_*te?sts?_*' +
     escapeRegExp(path.sep),
+
+  'node_modules' +
+    escapeRegExp(path.sep) +
+    '.*' +
+    escapeRegExp(path.sep) +
+    'tests?' +
+    escapeRegExp(path.sep),
+
   'node_modules' +
     escapeRegExp(path.sep) +
     '.*' +

--- a/script/lib/include-path-in-packaged-app.js
+++ b/script/lib/include-path-in-packaged-app.js
@@ -97,7 +97,29 @@ const EXCLUDE_REGEXPS_SOURCES = [
     escapeRegExp(path.sep),
   'node_modules' + escapeRegExp(path.sep) + '.*' + '\\.d\\.ts$',
   'node_modules' + escapeRegExp(path.sep) + '.*' + '\\.js\\.map$',
-  '.*' + escapeRegExp(path.sep) + 'test.*\\.html$'
+  '.*' + escapeRegExp(path.sep) + 'test.*\\.html$',
+
+  // specific spec folders hand-picked
+  'node_modules' +
+    escapeRegExp(path.sep) +
+    '(oniguruma|dev-live-reload|deprecation-cop|one-dark-ui|incompatible-packages|git-diff|line-ending-selector|link|grammar-selector|json-schema-traverse|exception-reporting|one-light-ui|autoflow|about|go-to-line|sylvester|apparatus)' +
+    escapeRegExp(path.sep) +
+    'spec' +
+    escapeRegExp(path.sep),
+
+  // babel-core spec
+  'node_modules' +
+    escapeRegExp(path.sep) +
+    'babel-core' +
+    escapeRegExp(path.sep) +
+    'lib' +
+    escapeRegExp(path.sep) +
+    'transformation' +
+    escapeRegExp(path.sep) +
+    'transforers' +
+    escapeRegExp(path.sep) +
+    'spec' +
+    escapeRegExp(path.sep)
 ];
 
 // Ignore spec directories in all bundled packages


### PR DESCRIPTION
### Description of the change

This excludes `node_modules/*/tests?` from being included in the final packaged Atom. This does not affect any testing as it only excludes these in the final Atom executable.

### Benefits
- Results in a smaller packaged app which means that loading it will be faster.
- The build time will be faster since the build scripts don't need to copy/transpile/compile the tests 

### Verification 
The tests are not needed in the packaged Atom. There was already a script for jest tests (__tests__), but that does not capture the tests by other libraries.