### PR TITLE
Parallel transpiling (build)

### DIFF
--- a/script/build
+++ b/script/build
@@ -63,8 +63,6 @@ process.on('unhandledRejection', function (e) {
 
 process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
 
-let binariesPromise = Promise.resolve()
-
 async function transpile() {
   const { spawn, Thread, Worker } = require(`${CONFIG.scriptRunnerModulesPath}/threads`)
 
@@ -105,26 +103,7 @@ async function transpile() {
   await Thread.terminate(prebuildLessCache)
 }
 
-async function build() {
-
-if (!argv.existingBinaries) {
-  checkChromedriverVersion()
-  cleanOutputDirectory()
-  copyAssets()
-  await transpile()
-  generateModuleCache()
-  generateMetadata()
-  generateAPIDocs()
-  if (!argv.generateApiDocs) {
-    binariesPromise = dumpSymbols()
-  }
-}
-
-if (!argv.generateApiDocs) {
-  binariesPromise
-    .then(packageApplication)
-    .then(packagedAppPath => generateStartupSnapshot(packagedAppPath).then(() => packagedAppPath))
-    .then(async packagedAppPath => {
+async function singAndCreateInstaller(packagedAppPath) {
       switch (process.platform) {
         case 'darwin': {
           if (argv.codeSign) {
@@ -179,7 +158,28 @@ if (!argv.generateApiDocs) {
       }
 
       return Promise.resolve(packagedAppPath)
-    }).then(packagedAppPath => {
+}
+
+
+async function build() {
+
+  if (!argv.existingBinaries) {
+    checkChromedriverVersion()
+    cleanOutputDirectory()
+    copyAssets()
+    await transpile()
+    generateModuleCache()
+    generateMetadata()
+    generateAPIDocs()
+    if (!argv.generateApiDocs) {
+      await dumpSymbols()
+    }
+  }
+
+  if (!argv.generateApiDocs) {
+      const packagedAppPath = await packageApplication()
+      await generateStartupSnapshot(packagedAppPath)
+      await singAndCreateInstaller(packagedAppPath)
       if (argv.compressArtifacts) {
         compressArtifacts(packagedAppPath)
       } else {
@@ -191,8 +191,7 @@ if (!argv.generateApiDocs) {
       } else {
         console.log('Skipping installation. Specify the --install option to install Atom'.gray)
       }
-    })
-}
+  }
 
 }
 

--- a/script/build
+++ b/script/build
@@ -54,13 +54,7 @@ const generateStartupSnapshot = require('./lib/generate-startup-snapshot')
 const installApplication = require('./lib/install-application')
 const notarizeOnMac = require('./lib/notarize-on-mac')
 const packageApplication = require('./lib/package-application')
-const prebuildLessCache = require('./lib/prebuild-less-cache')
 const testSignOnMac = require('./lib/test-sign-on-mac')
-const transpileBabelPaths = require('./lib/transpile-babel-paths')
-const transpileCoffeeScriptPaths = require('./lib/transpile-coffee-script-paths')
-const transpileCsonPaths = require('./lib/transpile-cson-paths')
-const transpilePegJsPaths = require('./lib/transpile-peg-js-paths')
-const transpilePackagesWithCustomTranspilerPaths = require('./lib/transpile-packages-with-custom-transpiler-paths.js')
 
 process.on('unhandledRejection', function (e) {
   console.error(e.stack || e)
@@ -71,17 +65,54 @@ process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
 
 let binariesPromise = Promise.resolve()
 
+async function transpile() {
+  const { spawn, Thread, Worker } = require(`${CONFIG.scriptRunnerModulesPath}/threads`)
+
+  const transpilePackagesWithCustomTranspilerPaths = await spawn(new Worker('./lib/transpile-packages-with-custom-transpiler-paths'))
+  const transpilePackagesWithCustomTranspilerPathsPromise = transpilePackagesWithCustomTranspilerPaths()
+
+  const transpileBabelPaths = await spawn(new Worker('./lib/transpile-babel-paths'))
+  const transpileBabelPathsPromise = transpileBabelPaths()
+
+  const transpileCoffeeScriptPaths = await spawn(new Worker('./lib/transpile-coffee-script-paths'))
+  const transpileCoffeeScriptPathsPromise = transpileCoffeeScriptPaths()
+
+  const transpileCsonPaths = await spawn(new Worker('./lib/transpile-cson-paths'))
+  const transpileCsonPathsPromise = transpileCsonPaths()
+
+  const transpilePegJsPaths = await spawn(new Worker('./lib/transpile-peg-js-paths'))
+  const transpilePegJsPathsPromise = transpilePegJsPaths()
+
+  const prebuildLessCache = await spawn(new Worker('./lib/prebuild-less-cache'))
+  const prebuildLessCachePromise = prebuildLessCache()
+
+  await transpilePackagesWithCustomTranspilerPathsPromise;
+  await Thread.terminate(transpilePackagesWithCustomTranspilerPaths)
+
+  await transpileBabelPathsPromise;
+  await Thread.terminate(transpileBabelPaths)
+
+  await transpileCoffeeScriptPathsPromise;
+  await Thread.terminate(transpileCoffeeScriptPaths)
+
+  await transpileCsonPathsPromise;
+  await Thread.terminate(transpileCsonPaths)
+
+  await transpilePegJsPathsPromise;
+  await Thread.terminate(transpilePegJsPaths)
+
+  await prebuildLessCachePromise;
+  await Thread.terminate(prebuildLessCache)
+}
+
+async function build() {
+
 if (!argv.existingBinaries) {
   checkChromedriverVersion()
   cleanOutputDirectory()
   copyAssets()
-  transpilePackagesWithCustomTranspilerPaths()
-  transpileBabelPaths()
-  transpileCoffeeScriptPaths()
-  transpileCsonPaths()
-  transpilePegJsPaths()
+  await transpile()
   generateModuleCache()
-  prebuildLessCache()
   generateMetadata()
   generateAPIDocs()
   if (!argv.generateApiDocs) {
@@ -162,3 +193,8 @@ if (!argv.generateApiDocs) {
       }
     })
 }
+
+}
+
+
+build().then(() => {process.exit(0)}).catch((e) =>  {throw e;})

--- a/script/build
+++ b/script/build
@@ -54,6 +54,7 @@ const generateStartupSnapshot = require('./lib/generate-startup-snapshot')
 const installApplication = require('./lib/install-application')
 const notarizeOnMac = require('./lib/notarize-on-mac')
 const packageApplication = require('./lib/package-application')
+const prebuildLessCache = require('./lib/prebuild-less-cache')
 const testSignOnMac = require('./lib/test-sign-on-mac')
 
 process.on('unhandledRejection', function (e) {
@@ -81,9 +82,6 @@ async function transpile() {
   const transpilePegJsPaths = await spawn(new Worker('./lib/transpile-peg-js-paths'))
   const transpilePegJsPathsPromise = transpilePegJsPaths()
 
-  const prebuildLessCache = await spawn(new Worker('./lib/prebuild-less-cache'))
-  const prebuildLessCachePromise = prebuildLessCache()
-
   await transpilePackagesWithCustomTranspilerPathsPromise;
   await Thread.terminate(transpilePackagesWithCustomTranspilerPaths)
 
@@ -98,9 +96,6 @@ async function transpile() {
 
   await transpilePegJsPathsPromise;
   await Thread.terminate(transpilePegJsPaths)
-
-  await prebuildLessCachePromise;
-  await Thread.terminate(prebuildLessCache)
 }
 
 async function singAndCreateInstaller(packagedAppPath) {
@@ -169,6 +164,7 @@ async function build() {
     copyAssets()
     await transpile()
     generateModuleCache()
+    prebuildLessCache()
     generateMetadata()
     generateAPIDocs()
     if (!argv.generateApiDocs) {

--- a/script/config.js
+++ b/script/config.js
@@ -126,4 +126,7 @@ function getNpmBinPath(external = false) {
     : npmBinName;
 }
 
-process.env.JOBS = 'max'; // parallel build in node-gyp
+// parallel build in node-gyp
+if (!process.env.JOBS) {
+  process.env.JOBS = 'max';
+}

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-function installApm(ci) {
+function installApm(ci = false, showVersion = true) {
   console.log('Installing apm');
   // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
@@ -12,9 +12,11 @@ function installApm(ci) {
     ['--global-style', '--loglevel=error', 'install'],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
-  childProcess.execFileSync(CONFIG.getApmBinPath(), ['--version'], {
-    stdio: 'inherit'
-  });
+  if (showVersion) {
+    childProcess.execFileSync(CONFIG.getApmBinPath(), ['--version'], {
+      stdio: 'inherit'
+    });
+  }
 }
 
 const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);

--- a/script/lib/install-script-runner-dependencies.js
+++ b/script/lib/install-script-runner-dependencies.js
@@ -4,8 +4,6 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
-
 function installScriptRunnerDependencies(ci) {
   console.log('Installing script runner dependencies');
   childProcess.execFileSync(

--- a/script/lib/prebuild-less-cache.js
+++ b/script/lib/prebuild-less-cache.js
@@ -11,7 +11,7 @@ const LESS_CACHE_VERSION = require('less-cache/package.json').version;
 const FALLBACK_VARIABLE_IMPORTS =
   '@import "variables/ui-variables";\n@import "variables/syntax-variables";\n';
 
-module.exports = function() {
+function prebuildLessCache() {
   const cacheDirPath = path.join(
     CONFIG.intermediateAppPath,
     'less-compile-cache'
@@ -215,4 +215,8 @@ module.exports = function() {
     lessCache.cssForFile(lessFilePath, lessSource);
     saveIntoSnapshotAuxiliaryData(lessFilePath, lessSource);
   }
-};
+}
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(prebuildLessCache);
+module.exports = prebuildLessCache;

--- a/script/lib/prebuild-less-cache.js
+++ b/script/lib/prebuild-less-cache.js
@@ -11,7 +11,7 @@ const LESS_CACHE_VERSION = require('less-cache/package.json').version;
 const FALLBACK_VARIABLE_IMPORTS =
   '@import "variables/ui-variables";\n@import "variables/syntax-variables";\n';
 
-function prebuildLessCache() {
+module.exports = function() {
   const cacheDirPath = path.join(
     CONFIG.intermediateAppPath,
     'less-compile-cache'
@@ -215,8 +215,4 @@ function prebuildLessCache() {
     lessCache.cssForFile(lessFilePath, lessSource);
     saveIntoSnapshotAuxiliaryData(lessFilePath, lessSource);
   }
-}
-
-const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
-expose(prebuildLessCache);
-module.exports = prebuildLessCache;
+};

--- a/script/lib/transpile-babel-paths.js
+++ b/script/lib/transpile-babel-paths.js
@@ -7,12 +7,12 @@ const path = require('path');
 
 const CONFIG = require('../config');
 
-module.exports = function() {
+function transpileBabelPaths() {
   console.log(`Transpiling Babel paths in ${CONFIG.intermediateAppPath}`);
   for (let path of getPathsToTranspile()) {
     transpileBabelPath(path);
   }
-};
+}
 
 function getPathsToTranspile() {
   let paths = [];
@@ -49,3 +49,7 @@ function transpileBabelPath(path) {
     CompileCache.addPathToCache(path, CONFIG.atomHomeDirPath)
   );
 }
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(transpileBabelPaths);
+module.exports = transpileBabelPaths;

--- a/script/lib/transpile-coffee-script-paths.js
+++ b/script/lib/transpile-coffee-script-paths.js
@@ -7,14 +7,14 @@ const path = require('path');
 
 const CONFIG = require('../config');
 
-module.exports = function() {
+function transpileCoffeeScriptPaths() {
   console.log(
     `Transpiling CoffeeScript paths in ${CONFIG.intermediateAppPath}`
   );
   for (let path of getPathsToTranspile()) {
     transpileCoffeeScriptPath(path);
   }
-};
+}
 
 function getPathsToTranspile() {
   let paths = [];
@@ -63,3 +63,7 @@ function transpileCoffeeScriptPath(coffeePath) {
   );
   fs.unlinkSync(coffeePath);
 }
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(transpileCoffeeScriptPaths);
+module.exports = transpileCoffeeScriptPaths;

--- a/script/lib/transpile-cson-paths.js
+++ b/script/lib/transpile-cson-paths.js
@@ -7,12 +7,12 @@ const path = require('path');
 
 const CONFIG = require('../config');
 
-module.exports = function() {
+function transpileCsonPaths() {
   console.log(`Transpiling CSON paths in ${CONFIG.intermediateAppPath}`);
   for (let path of getPathsToTranspile()) {
     transpileCsonPath(path);
   }
-};
+}
 
 function getPathsToTranspile() {
   let paths = [];
@@ -53,3 +53,7 @@ function transpileCsonPath(csonPath) {
   );
   fs.unlinkSync(csonPath);
 }
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(transpileCsonPaths);
+module.exports = transpileCsonPaths;

--- a/script/lib/transpile-packages-with-custom-transpiler-paths.js
+++ b/script/lib/transpile-packages-with-custom-transpiler-paths.js
@@ -11,7 +11,7 @@ const runApmInstall = require('./run-apm-install');
 
 require('colors');
 
-module.exports = function() {
+function transpilePackagesWithCustomTranspilerPaths() {
   console.log(
     `Transpiling packages with custom transpiler configurations in ${
       CONFIG.intermediateAppPath
@@ -78,7 +78,7 @@ module.exports = function() {
       intermediatePackageBackup.restore();
     }
   }
-};
+}
 
 function transpilePath(path) {
   fs.writeFileSync(
@@ -86,3 +86,7 @@ function transpilePath(path) {
     CompileCache.addPathToCache(path, CONFIG.atomHomeDirPath)
   );
 }
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(transpilePackagesWithCustomTranspilerPaths);
+module.exports = transpilePackagesWithCustomTranspilerPaths;

--- a/script/lib/transpile-peg-js-paths.js
+++ b/script/lib/transpile-peg-js-paths.js
@@ -7,12 +7,12 @@ const path = require('path');
 
 const CONFIG = require('../config');
 
-module.exports = function() {
+function transpilePegJsPaths() {
   console.log(`Transpiling PEG.js paths in ${CONFIG.intermediateAppPath}`);
   for (let path of getPathsToTranspile()) {
     transpilePegJsPath(path);
   }
-};
+}
 
 function getPathsToTranspile() {
   let paths = [];
@@ -41,3 +41,7 @@ function transpilePegJsPath(pegJsPath) {
   fs.writeFileSync(jsPath, outputCode);
   fs.unlinkSync(pegJsPath);
 }
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(transpilePegJsPaths);
+module.exports = transpilePegJsPaths;


### PR DESCRIPTION
### Description of the change

This PR parallelizes the transpiling part of the build, so they run on different threads. This is built on top of #21308 and uses threads as its script-runner. The changes to the scripts/lib are very minimal. The build script is changed to support running the threads. 

Note: This PR is part of the series that speed up the build/bootstrap of Atom #21308 #21342 #21398 and more PRs that are coming (such as parallelizing copy assets, clean, etc). See https://github.com/atom-ide-community/atom/pull/155.

### Verification
The local builds/CI pass all the tests,

### Benefits
Results in a faster building of Atom locally or in the CI.

### Release Notes
Faster building by using threads for transpiling.