### PR TITLE
Refactor TextEditor updating 

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4207,7 +4207,7 @@ module.exports = class TextEditor {
   // * `softTabs` A {Boolean}
   setSoftTabs(softTabs) {
     this.softTabs = softTabs;
-    this.update({ softTabs: this.softTabs });
+    this.updateSoftTabs(this.softTabs, true);
   }
 
   // Returns a {Boolean} indicating whether atomic soft tabs are enabled for this editor.

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -457,24 +457,7 @@ module.exports = class TextEditor {
           break;
 
         case 'mini':
-          if (value !== this.mini) {
-            this.mini = value;
-            this.emitter.emit('did-change-mini', value);
-            displayLayerParams.invisibles = this.getInvisibles();
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-            displayLayerParams.showIndentGuides = this.doesShowIndentGuide();
-            if (this.mini) {
-              for (let decoration of this.cursorLineDecorations) {
-                decoration.destroy();
-              }
-              this.cursorLineDecorations = null;
-            } else {
-              this.decorateCursorLine();
-            }
-            if (this.component != null) {
-              this.component.scheduleUpdate();
-            }
-          }
+          this.updateMini(value, false, displayLayerParams);
           break;
 
         case 'readOnly':
@@ -688,6 +671,28 @@ module.exports = class TextEditor {
     if (value !== this.maxScreenLineLength) {
       this.maxScreenLineLength = value;
       displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateMini(value, finish, displayLayerParams = {}) {
+    if (value !== this.mini) {
+      this.mini = value;
+      this.emitter.emit('did-change-mini', value);
+      displayLayerParams.invisibles = this.getInvisibles();
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
+      displayLayerParams.showIndentGuides = this.doesShowIndentGuide();
+      if (this.mini) {
+        for (let decoration of this.cursorLineDecorations) {
+          decoration.destroy();
+        }
+        this.cursorLineDecorations = null;
+      } else {
+        this.decorateCursorLine();
+      }
+      if (this.component != null) {
+        this.component.scheduleUpdate();
+      }
     }
     if (finish) this.finishUpdate(displayLayerParams);
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -429,11 +429,7 @@ module.exports = class TextEditor {
           break;
 
         case 'softWrapped':
-          if (value !== this.softWrapped) {
-            this.softWrapped = value;
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-            this.emitter.emit('did-change-soft-wrapped', this.isSoftWrapped());
-          }
+          this.updateSoftWrapped(value, false, displayLayerParams);
           break;
 
         case 'softWrapHangingIndentLength':
@@ -655,6 +651,15 @@ module.exports = class TextEditor {
   updateTabLength(value, finish, displayLayerParams = {}) {
     if (value > 0 && value !== this.displayLayer.tabLength) {
       displayLayerParams.tabLength = value;
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateSoftWrapped(value, finish, displayLayerParams = {}) {
+    if (value !== this.softWrapped) {
+      this.softWrapped = value;
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
+      this.emitter.emit('did-change-soft-wrapped', this.isSoftWrapped());
     }
     if (finish) this.finishUpdate(displayLayerParams);
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4233,7 +4233,7 @@ module.exports = class TextEditor {
   // * `tabLength` {Number} length of a single tab. Setting to `null` will
   //   fallback to using the `editor.tabLength` config setting
   setTabLength(tabLength) {
-    this.update({ tabLength });
+    this.updateTabLength(tabLength, true);
   }
 
   // Returns an {Object} representing the current invisible character

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -501,10 +501,7 @@ module.exports = class TextEditor {
           break;
 
         case 'scrollPastEnd':
-          if (value !== this.scrollPastEnd) {
-            this.scrollPastEnd = value;
-            if (this.component) this.component.scheduleUpdate();
-          }
+          this.updateScrollPastEnd(value, false);
           break;
 
         case 'autoHeight':
@@ -745,6 +742,14 @@ module.exports = class TextEditor {
       displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
     }
     if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateScrollPastEnd(value, finish) {
+    if (value !== this.scrollPastEnd) {
+      this.scrollPastEnd = value;
+      if (this.component) this.component.scheduleUpdate();
+    }
+    if (finish) this.finishUpdate();
   }
 
   scheduleComponentUpdate() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -497,10 +497,7 @@ module.exports = class TextEditor {
           break;
 
         case 'width':
-          if (value !== this.width) {
-            this.width = value;
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-          }
+          this.updateWidth(value, false, displayLayerParams);
           break;
 
         case 'scrollPastEnd':
@@ -737,6 +734,14 @@ module.exports = class TextEditor {
   updateEditorWidthInChars(value, finish, displayLayerParams = {}) {
     if (value > 0 && value !== this.editorWidthInChars) {
       this.editorWidthInChars = value;
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateWidth(value, finish, displayLayerParams = {}) {
+    if (value !== this.width) {
+      this.width = value;
       displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
     }
     if (finish) this.finishUpdate(displayLayerParams);

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -453,10 +453,7 @@ module.exports = class TextEditor {
           break;
 
         case 'maxScreenLineLength':
-          if (value !== this.maxScreenLineLength) {
-            this.maxScreenLineLength = value;
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-          }
+          this.updateMaxScreenLineLength(value, false, displayLayerParams);
           break;
 
         case 'mini':
@@ -682,6 +679,14 @@ module.exports = class TextEditor {
   updatePreferredLineLength(value, finish, displayLayerParams = {}) {
     if (value !== this.preferredLineLength) {
       this.preferredLineLength = value;
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateMaxScreenLineLength(value, finish, displayLayerParams = {}) {
+    if (value !== this.maxScreenLineLength) {
+      this.maxScreenLineLength = value;
       displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
     }
     if (finish) this.finishUpdate(displayLayerParams);

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1289,7 +1289,7 @@ module.exports = class TextEditor {
   }
 
   setLineNumberGutterVisible(lineNumberGutterVisible) {
-    this.update({ lineNumberGutterVisible });
+    this.updateLineNumberGutterVisible(lineNumberGutterVisible, true);
   }
 
   isLineNumberGutterVisible() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -469,10 +469,7 @@ module.exports = class TextEditor {
           break;
 
         case 'placeholderText':
-          if (value !== this.placeholderText) {
-            this.placeholderText = value;
-            this.emitter.emit('did-change-placeholder-text', value);
-          }
+          this.updatePlaceholderText(value, false);
           break;
 
         case 'lineNumberGutterVisible':
@@ -703,6 +700,14 @@ module.exports = class TextEditor {
       if (this.component != null) {
         this.component.scheduleUpdate();
       }
+    }
+    if (finish) this.finishUpdate();
+  }
+
+  updatePlaceholderText(value, finish) {
+    if (value !== this.placeholderText) {
+      this.placeholderText = value;
+      this.emitter.emit('did-change-placeholder-text', value);
     }
     if (finish) this.finishUpdate();
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -513,10 +513,7 @@ module.exports = class TextEditor {
           break;
 
         case 'showCursorOnSelection':
-          if (value !== this.showCursorOnSelection) {
-            this.showCursorOnSelection = value;
-            if (this.component) this.component.scheduleUpdate();
-          }
+          this.updateShowCursorOnSelection(value, false);
           break;
 
         default:
@@ -758,6 +755,14 @@ module.exports = class TextEditor {
   updateAutoWidth(value, finish) {
     if (value !== this.autoWidth) {
       this.autoWidth = value;
+    }
+    if (finish) this.finishUpdate();
+  }
+
+  updateShowCursorOnSelection(value, finish) {
+    if (value !== this.showCursorOnSelection) {
+      this.showCursorOnSelection = value;
+      if (this.component) this.component.scheduleUpdate();
     }
     if (finish) this.finishUpdate();
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1343,7 +1343,7 @@ module.exports = class TextEditor {
   // * `editorWidthInChars` A {Number} representing the width of the
   // {TextEditorElement} in characters.
   setEditorWidthInChars(editorWidthInChars) {
-    this.update({ editorWidthInChars });
+    this.updateEditorWidthInChars(editorWidthInChars, true);
   }
 
   // Returns the editor width in characters.

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -606,6 +606,10 @@ module.exports = class TextEditor {
       }
     }
 
+    return this.finishUpdate(displayLayerParams);
+  }
+
+  finishUpdate(displayLayerParams = {}) {
     this.displayLayer.reset(displayLayerParams);
 
     if (this.component) {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -449,10 +449,7 @@ module.exports = class TextEditor {
           break;
 
         case 'preferredLineLength':
-          if (value !== this.preferredLineLength) {
-            this.preferredLineLength = value;
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-          }
+          this.updatePreferredLineLength(value, false, displayLayerParams);
           break;
 
         case 'maxScreenLineLength':
@@ -677,6 +674,14 @@ module.exports = class TextEditor {
   updateSoftWrapAtPreferredLineLength(value, finish, displayLayerParams = {}) {
     if (value !== this.softWrapAtPreferredLineLength) {
       this.softWrapAtPreferredLineLength = value;
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updatePreferredLineLength(value, finish, displayLayerParams = {}) {
+    if (value !== this.preferredLineLength) {
+      this.preferredLineLength = value;
       displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
     }
     if (finish) this.finishUpdate(displayLayerParams);

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -477,10 +477,7 @@ module.exports = class TextEditor {
           break;
 
         case 'showIndentGuide':
-          if (value !== this.showIndentGuide) {
-            this.showIndentGuide = value;
-            displayLayerParams.showIndentGuides = this.doesShowIndentGuide();
-          }
+          this.updateShowIndentGuide(value, false, displayLayerParams);
           break;
 
         case 'showLineNumbers':
@@ -715,6 +712,14 @@ module.exports = class TextEditor {
       );
     }
     if (finish) this.finishUpdate();
+  }
+
+  updateShowIndentGuide(value, finish, displayLayerParams = {}) {
+    if (value !== this.showIndentGuide) {
+      this.showIndentGuide = value;
+      displayLayerParams.showIndentGuides = this.doesShowIndentGuide();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
   }
 
   scheduleComponentUpdate() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -465,12 +465,7 @@ module.exports = class TextEditor {
           break;
 
         case 'keyboardInputEnabled':
-          if (value !== this.keyboardInputEnabled) {
-            this.keyboardInputEnabled = value;
-            if (this.component != null) {
-              this.component.scheduleUpdate();
-            }
-          }
+          this.updateKeyboardInputEnabled(value, false);
           break;
 
         case 'placeholderText':
@@ -695,6 +690,16 @@ module.exports = class TextEditor {
   updateReadOnly(value, finish) {
     if (value !== this.readOnly) {
       this.readOnly = value;
+      if (this.component != null) {
+        this.component.scheduleUpdate();
+      }
+    }
+    if (finish) this.finishUpdate();
+  }
+
+  updateKeyboardInputEnabled(value, finish) {
+    if (value !== this.keyboardInputEnabled) {
+      this.keyboardInputEnabled = value;
       if (this.component != null) {
         this.component.scheduleUpdate();
       }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1261,7 +1261,7 @@ module.exports = class TextEditor {
   }
 
   setMini(mini) {
-    this.update({ mini });
+    this.updateMini(mini, true);
   }
 
   isMini() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -421,9 +421,7 @@ module.exports = class TextEditor {
           break;
 
         case 'atomicSoftTabs':
-          if (value !== this.displayLayer.atomicSoftTabs) {
-            displayLayerParams.atomicSoftTabs = value;
-          }
+          this.updateAtomicSoftTabs(value, false, displayLayerParams);
           break;
 
         case 'tabLength':
@@ -647,6 +645,13 @@ module.exports = class TextEditor {
       this.softTabs = value;
     }
     if (finish) this.finishUpdate();
+  }
+
+  updateAtomicSoftTabs(value, finish, displayLayerParams = {}) {
+    if (value !== this.displayLayer.atomicSoftTabs) {
+      displayLayerParams.atomicSoftTabs = value;
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
   }
 
   scheduleComponentUpdate() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -417,9 +417,7 @@ module.exports = class TextEditor {
           break;
 
         case 'softTabs':
-          if (value !== this.softTabs) {
-            this.softTabs = value;
-          }
+          this.updateSoftTabs(value, false);
           break;
 
         case 'atomicSoftTabs':
@@ -641,6 +639,13 @@ module.exports = class TextEditor {
 
   updateEncoding(value, finish) {
     this.buffer.setEncoding(value);
+    if (finish) this.finishUpdate();
+  }
+
+  updateSoftTabs(value, finish) {
+    if (value !== this.softTabs) {
+      this.softTabs = value;
+    }
     if (finish) this.finishUpdate();
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -493,10 +493,7 @@ module.exports = class TextEditor {
           break;
 
         case 'editorWidthInChars':
-          if (value > 0 && value !== this.editorWidthInChars) {
-            this.editorWidthInChars = value;
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-          }
+          this.updateEditorWidthInChars(value, false, displayLayerParams);
           break;
 
         case 'width':
@@ -733,6 +730,14 @@ module.exports = class TextEditor {
     if (!_.isEqual(value, this.invisibles)) {
       this.invisibles = value;
       displayLayerParams.invisibles = this.getInvisibles();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateEditorWidthInChars(value, finish, displayLayerParams = {}) {
+    if (value > 0 && value !== this.editorWidthInChars) {
+      this.editorWidthInChars = value;
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
     }
     if (finish) this.finishUpdate(displayLayerParams);
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -505,9 +505,7 @@ module.exports = class TextEditor {
           break;
 
         case 'autoHeight':
-          if (value !== this.autoHeight) {
-            this.autoHeight = value;
-          }
+          this.updateAutoHight(value, false);
           break;
 
         case 'autoWidth':
@@ -748,6 +746,13 @@ module.exports = class TextEditor {
     if (value !== this.scrollPastEnd) {
       this.scrollPastEnd = value;
       if (this.component) this.component.scheduleUpdate();
+    }
+    if (finish) this.finishUpdate();
+  }
+
+  updateAutoHight(value, finish) {
+    if (value !== this.autoHeight) {
+      this.autoHeight = value;
     }
     if (finish) this.finishUpdate();
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4316,7 +4316,7 @@ module.exports = class TextEditor {
   //
   // Returns a {Boolean}.
   setSoftWrapped(softWrapped) {
-    this.update({ softWrapped });
+    this.updateSoftWrapped(softWrapped, true);
     return this.isSoftWrapped();
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -509,9 +509,7 @@ module.exports = class TextEditor {
           break;
 
         case 'autoWidth':
-          if (value !== this.autoWidth) {
-            this.autoWidth = value;
-          }
+          this.updateAutoWidth(value, false);
           break;
 
         case 'showCursorOnSelection':
@@ -753,6 +751,13 @@ module.exports = class TextEditor {
   updateAutoHight(value, finish) {
     if (value !== this.autoHeight) {
       this.autoHeight = value;
+    }
+    if (finish) this.finishUpdate();
+  }
+
+  updateAutoWidth(value, finish) {
+    if (value !== this.autoWidth) {
+      this.autoWidth = value;
     }
     if (finish) this.finishUpdate();
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1277,7 +1277,7 @@ module.exports = class TextEditor {
   }
 
   enableKeyboardInput(enabled) {
-    this.update({ keyboardInputEnabled: enabled });
+    this.updateKeyboardInputEnabled(enabled, true);
   }
 
   isKeyboardInputEnabled() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -413,7 +413,7 @@ module.exports = class TextEditor {
           break;
 
         case 'encoding':
-          this.buffer.setEncoding(value);
+          this.updateEncoding(value, false);
           break;
 
         case 'softTabs':
@@ -636,6 +636,11 @@ module.exports = class TextEditor {
 
   updateScrollSensitivity(value, finish) {
     this.scrollSensitivity = value;
+    if (finish) this.finishUpdate();
+  }
+
+  updateEncoding(value, finish) {
+    this.buffer.setEncoding(value);
     if (finish) this.finishUpdate();
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -409,7 +409,7 @@ module.exports = class TextEditor {
           break;
 
         case 'scrollSensitivity':
-          this.scrollSensitivity = value;
+          this.updateScrollSensitivity(value, false);
           break;
 
         case 'encoding':
@@ -631,6 +631,11 @@ module.exports = class TextEditor {
 
   updateUndoGroupingInterval(value, finish) {
     this.undoGroupingInterval = value;
+    if (finish) this.finishUpdate();
+  }
+
+  updateScrollSensitivity(value, finish) {
+    this.scrollSensitivity = value;
     if (finish) this.finishUpdate();
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -5256,7 +5256,7 @@ module.exports = class TextEditor {
   //
   // * `placeholderText` {String} text that is displayed when the editor has no content.
   setPlaceholderText(placeholderText) {
-    this.update({ placeholderText });
+    this.updatePlaceholderText(placeholderText, true);
   }
 
   pixelPositionForBufferPosition(bufferPosition) {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -473,17 +473,7 @@ module.exports = class TextEditor {
           break;
 
         case 'lineNumberGutterVisible':
-          if (value !== this.lineNumberGutterVisible) {
-            if (value) {
-              this.lineNumberGutter.show();
-            } else {
-              this.lineNumberGutter.hide();
-            }
-            this.emitter.emit(
-              'did-change-line-number-gutter-visible',
-              this.lineNumberGutter.isVisible()
-            );
-          }
+          this.updateLineNumberGutterVisible(value, false);
           break;
 
         case 'showIndentGuide':
@@ -708,6 +698,21 @@ module.exports = class TextEditor {
     if (value !== this.placeholderText) {
       this.placeholderText = value;
       this.emitter.emit('did-change-placeholder-text', value);
+    }
+    if (finish) this.finishUpdate();
+  }
+
+  updateLineNumberGutterVisible(value, finish) {
+    if (value !== this.lineNumberGutterVisible) {
+      if (value) {
+        this.lineNumberGutter.show();
+      } else {
+        this.lineNumberGutter.hide();
+      }
+      this.emitter.emit(
+        'did-change-line-number-gutter-visible',
+        this.lineNumberGutter.isVisible()
+      );
     }
     if (finish) this.finishUpdate();
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -425,9 +425,7 @@ module.exports = class TextEditor {
           break;
 
         case 'tabLength':
-          if (value > 0 && value !== this.displayLayer.tabLength) {
-            displayLayerParams.tabLength = value;
-          }
+          this.updateTabLength(value, false, displayLayerParams);
           break;
 
         case 'softWrapped':
@@ -650,6 +648,13 @@ module.exports = class TextEditor {
   updateAtomicSoftTabs(value, finish, displayLayerParams = {}) {
     if (value !== this.displayLayer.atomicSoftTabs) {
       displayLayerParams.atomicSoftTabs = value;
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateTabLength(value, finish, displayLayerParams = {}) {
+    if (value > 0 && value !== this.displayLayer.tabLength) {
+      displayLayerParams.tabLength = value;
     }
     if (finish) this.finishUpdate(displayLayerParams);
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -481,12 +481,7 @@ module.exports = class TextEditor {
           break;
 
         case 'showLineNumbers':
-          if (value !== this.showLineNumbers) {
-            this.showLineNumbers = value;
-            if (this.component != null) {
-              this.component.scheduleUpdate();
-            }
-          }
+          this.updateShowLineNumbers(value, false);
           break;
 
         case 'showInvisibles':
@@ -720,6 +715,16 @@ module.exports = class TextEditor {
       displayLayerParams.showIndentGuides = this.doesShowIndentGuide();
     }
     if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateShowLineNumbers(value, finish) {
+    if (value !== this.showLineNumbers) {
+      this.showLineNumbers = value;
+      if (this.component != null) {
+        this.component.scheduleUpdate();
+      }
+    }
+    if (finish) this.finishUpdate();
   }
 
   scheduleComponentUpdate() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -405,7 +405,7 @@ module.exports = class TextEditor {
           break;
 
         case 'undoGroupingInterval':
-          this.undoGroupingInterval = value;
+          this.updateUndoGroupingInterval(value, false);
           break;
 
         case 'scrollSensitivity':
@@ -626,6 +626,11 @@ module.exports = class TextEditor {
 
   updateAutoIndentOnPaste(value, finish) {
     this.autoIndentOnPaste = value;
+    if (finish) this.finishUpdate();
+  }
+
+  updateUndoGroupingInterval(value, finish) {
+    this.undoGroupingInterval = value;
     if (finish) this.finishUpdate();
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -461,12 +461,7 @@ module.exports = class TextEditor {
           break;
 
         case 'readOnly':
-          if (value !== this.readOnly) {
-            this.readOnly = value;
-            if (this.component != null) {
-              this.component.scheduleUpdate();
-            }
-          }
+          this.updateReadOnly(value, false);
           break;
 
         case 'keyboardInputEnabled':
@@ -695,6 +690,16 @@ module.exports = class TextEditor {
       }
     }
     if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateReadOnly(value, finish) {
+    if (value !== this.readOnly) {
+      this.readOnly = value;
+      if (this.component != null) {
+        this.component.scheduleUpdate();
+      }
+    }
+    if (finish) this.finishUpdate();
   }
 
   scheduleComponentUpdate() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -401,7 +401,7 @@ module.exports = class TextEditor {
           break;
 
         case 'autoIndentOnPaste':
-          this.autoIndentOnPaste = value;
+          this.updateAutoIndentOnPaste(value, false);
           break;
 
         case 'undoGroupingInterval':
@@ -621,6 +621,11 @@ module.exports = class TextEditor {
 
   updateAutoIndent(value, finish) {
     this.autoIndent = value;
+    if (finish) this.finishUpdate();
+  }
+
+  updateAutoIndentOnPaste(value, finish) {
+    this.autoIndentOnPaste = value;
     if (finish) this.finishUpdate();
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -397,7 +397,7 @@ module.exports = class TextEditor {
 
       switch (param) {
         case 'autoIndent':
-          this.autoIndent = value;
+          this.updateAutoIndent(value, false);
           break;
 
         case 'autoIndentOnPaste':
@@ -617,6 +617,11 @@ module.exports = class TextEditor {
     } else {
       return Promise.resolve();
     }
+  }
+
+  updateAutoIndent(value, finish) {
+    this.autoIndent = value;
+    if (finish) this.finishUpdate();
   }
 
   scheduleComponentUpdate() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -489,10 +489,7 @@ module.exports = class TextEditor {
           break;
 
         case 'invisibles':
-          if (!_.isEqual(value, this.invisibles)) {
-            this.invisibles = value;
-            displayLayerParams.invisibles = this.getInvisibles();
-          }
+          this.updateInvisibles(value, false, displayLayerParams);
           break;
 
         case 'editorWidthInChars':
@@ -727,6 +724,14 @@ module.exports = class TextEditor {
   updateShowInvisibles(value, finish, displayLayerParams = {}) {
     if (value !== this.showInvisibles) {
       this.showInvisibles = value;
+      displayLayerParams.invisibles = this.getInvisibles();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateInvisibles(value, finish, displayLayerParams = {}) {
+    if (!_.isEqual(value, this.invisibles)) {
+      this.invisibles = value;
       displayLayerParams.invisibles = this.getInvisibles();
     }
     if (finish) this.finishUpdate(displayLayerParams);

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -441,10 +441,11 @@ module.exports = class TextEditor {
           break;
 
         case 'softWrapAtPreferredLineLength':
-          if (value !== this.softWrapAtPreferredLineLength) {
-            this.softWrapAtPreferredLineLength = value;
-            displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
-          }
+          this.updateSoftWrapAtPreferredLineLength(
+            value,
+            false,
+            displayLayerParams
+          );
           break;
 
         case 'preferredLineLength':
@@ -669,6 +670,14 @@ module.exports = class TextEditor {
   updateSoftWrapHangingIndentLength(value, finish, displayLayerParams = {}) {
     if (value !== this.displayLayer.softWrapHangingIndent) {
       displayLayerParams.softWrapHangingIndent = value;
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateSoftWrapAtPreferredLineLength(value, finish, displayLayerParams = {}) {
+    if (value !== this.softWrapAtPreferredLineLength) {
+      this.softWrapAtPreferredLineLength = value;
+      displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
     }
     if (finish) this.finishUpdate(displayLayerParams);
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -433,9 +433,11 @@ module.exports = class TextEditor {
           break;
 
         case 'softWrapHangingIndentLength':
-          if (value !== this.displayLayer.softWrapHangingIndent) {
-            displayLayerParams.softWrapHangingIndent = value;
-          }
+          this.updateSoftWrapHangingIndentLength(
+            value,
+            false,
+            displayLayerParams
+          );
           break;
 
         case 'softWrapAtPreferredLineLength':
@@ -660,6 +662,13 @@ module.exports = class TextEditor {
       this.softWrapped = value;
       displayLayerParams.softWrapColumn = this.getSoftWrapColumn();
       this.emitter.emit('did-change-soft-wrapped', this.isSoftWrapped());
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
+  }
+
+  updateSoftWrapHangingIndentLength(value, finish, displayLayerParams = {}) {
+    if (value !== this.displayLayer.softWrapHangingIndent) {
+      displayLayerParams.softWrapHangingIndent = value;
     }
     if (finish) this.finishUpdate(displayLayerParams);
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1269,7 +1269,7 @@ module.exports = class TextEditor {
   }
 
   setReadOnly(readOnly) {
-    this.update({ readOnly });
+    this.updateReadOnly(readOnly, true);
   }
 
   isReadOnly() {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -485,10 +485,7 @@ module.exports = class TextEditor {
           break;
 
         case 'showInvisibles':
-          if (value !== this.showInvisibles) {
-            this.showInvisibles = value;
-            displayLayerParams.invisibles = this.getInvisibles();
-          }
+          this.updateShowInvisibles(value, false, displayLayerParams);
           break;
 
         case 'invisibles':
@@ -725,6 +722,14 @@ module.exports = class TextEditor {
       }
     }
     if (finish) this.finishUpdate();
+  }
+
+  updateShowInvisibles(value, finish, displayLayerParams = {}) {
+    if (value !== this.showInvisibles) {
+      this.showInvisibles = value;
+      displayLayerParams.invisibles = this.getInvisibles();
+    }
+    if (finish) this.finishUpdate(displayLayerParams);
   }
 
   scheduleComponentUpdate() {


### PR DESCRIPTION
### Description of the change

This PR refactors the codes that were responsible for updating different parts of TextEditor out of `update` function, and, then, it uses those refactored functions directly, which bypasses the loop and switch case inside `update`.

`finishUpdate` is also refactored that allows finishing updating of TextEditor from inside themselves without the need for creating objects outside and passing them in.

### Benefits
- This reduces the complexity of the update algorithm for those that are updated directly (`O(n^2)`->`O(1)`). This removes the overhead of checking for the given value against the keys in switch-case, and it also removes the overhead of the for-loop. Directly calling these functions is similar to the compile-time method dispatch used in other languages like C++. The previous method was a runtime dispatch algorithm that does not allow the V8 engine to optimize these calls and indirections.

- Having these functions separate makes it easier to maintain, find, and reason about them. 

### Verification

I have moved the code inside `update` to a separate function as it is (exact copy-paste), and I have not changed "any part of the actual code". If you follow my commits one by one, you will see that the moved code is kept exactly identical.

All the tests must pass because this does not change the functionality. 

### Release Notes
- Refactor the codes that were responsible for updating different parts of TextEditor